### PR TITLE
Fix: Only INFO level logs are delteded when LogCleaner is enabled

### DIFF
--- a/cmake/RunCleanerTest1.cmake
+++ b/cmake/RunCleanerTest1.cmake
@@ -15,8 +15,9 @@ list (LENGTH LOG_FILES NUM_FILES)
 if (WIN32)
   # On Windows open files cannot be removed and will result in a permission
   # denied error while unlinking such file. Therefore, the last file will be
-  # retained.
-  set (_expected 1)
+  # retained. The cleanup_immediately_unittest.cc file uses three log levels,
+  # so _expected is set to 3.
+  set (_expected 3)
  else (WIN32)
   set (_expected 0)
 endif (WIN32)

--- a/src/cleanup_immediately_unittest.cc
+++ b/src/cleanup_immediately_unittest.cc
@@ -61,6 +61,8 @@ TEST(CleanImmediately, logging) {
 
   for (unsigned i = 0; i < 1000; ++i) {
     LOG(INFO) << "cleanup test";
+    LOG(WARNING) << "cleanup test";
+    LOG(ERROR) << "cleanup test";
   }
 
   nglog::DisableLogCleaner();


### PR DESCRIPTION
Maintain separate `next_cleanup_time` for each base_filename to ensure that all logs can be cleaned by LogCleaner

Fixes: #2