### PR TITLE
Fix missing -std=gnu++14 flag when building unit tests on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -550,6 +550,8 @@ if (BUILD_TESTING)
     $<TARGET_PROPERTY:ng-log,LINK_LIBRARIES>)
   target_compile_definitions (ng-log_test INTERFACE NGLOG_STATIC_DEFINE
     $<TARGET_PROPERTY:ng-log,COMPILE_DEFINITIONS>)
+  target_compile_features (ng-log_test INTERFACE
+    $<TARGET_PROPERTY:ng-log,COMPILE_FEATURES>)
   target_include_directories (ng-log_test INTERFACE $<TARGET_PROPERTY:ng-log,INCLUDE_DIRECTORIES>)
 
   if (HAVE_LIB_GTEST)


### PR DESCRIPTION
Hello!

I'm trying to add ng-log to vcpkg yesterday (https://github.com/microsoft/vcpkg/pull/46413), and I encountered some compilation errors on macOS:
https://github.com/microsoft/vcpkg/runs/45877687051

<details>
<summary>Build log:</summary>

```
Change Dir: '/Users/vcpkg/Data/b/ng-log/x64-osx-dbg'

Run Build Command(s): /usr/local/bin/ninja -v -v -j13 install
[1/41] /Library/Developer/CommandLineTools/usr/bin/c++ -DGFLAGS_IS_A_DLL=0 -DNGLOG_NO_SYMBOLIZE_DETECTION -DNGLOG_USE_EXPORT -DNGLOG_USE_GFLAGS -Dng_log_EXPORTS -I/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src -I/Users/vcpkg/Data/b/ng-log/x64-osx-dbg -I/Users/vcpkg/Data/installed/x64-osx/include -fPIC -g -std=gnu++14 -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT CMakeFiles/ng-log_internal.dir/src/stacktrace.cc.o -MF CMakeFiles/ng-log_internal.dir/src/stacktrace.cc.o.d -o CMakeFiles/ng-log_internal.dir/src/stacktrace.cc.o -c /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/stacktrace.cc
[2/41] /Library/Developer/CommandLineTools/usr/bin/c++ -DGFLAGS_IS_A_DLL=0 -DNGLOG_NO_SYMBOLIZE_DETECTION -DNGLOG_USE_EXPORT -DNGLOG_USE_GFLAGS -Dng_log_EXPORTS -I/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src -I/Users/vcpkg/Data/b/ng-log/x64-osx-dbg -I/Users/vcpkg/Data/installed/x64-osx/include -fPIC -g -std=gnu++14 -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT CMakeFiles/ng-log_internal.dir/src/symbolize.cc.o -MF CMakeFiles/ng-log_internal.dir/src/symbolize.cc.o.d -o CMakeFiles/ng-log_internal.dir/src/symbolize.cc.o -c /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/symbolize.cc
[3/41] /Library/Developer/CommandLineTools/usr/bin/c++ -DGFLAGS_IS_A_DLL=0 -DNGLOG_NO_SYMBOLIZE_DETECTION -DNGLOG_USE_EXPORT -DNGLOG_USE_GFLAGS -Dng_log_EXPORTS -I/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src -I/Users/vcpkg/Data/b/ng-log/x64-osx-dbg -I/Users/vcpkg/Data/installed/x64-osx/include -fPIC -g -std=gnu++14 -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT CMakeFiles/ng-log_internal.dir/src/demangle.cc.o -MF CMakeFiles/ng-log_internal.dir/src/demangle.cc.o.d -o CMakeFiles/ng-log_internal.dir/src/demangle.cc.o -c /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/demangle.cc
[4/41] /Library/Developer/CommandLineTools/usr/bin/c++ -DGFLAGS_IS_A_DLL=0 -DNGLOG_NO_SYMBOLIZE_DETECTION -DNGLOG_USE_EXPORT -DNGLOG_USE_GFLAGS -Dng_log_EXPORTS -I/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src -I/Users/vcpkg/Data/b/ng-log/x64-osx-dbg -I/Users/vcpkg/Data/installed/x64-osx/include -fPIC -g -std=gnu++14 -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT CMakeFiles/ng-log_internal.dir/src/vlog_is_on.cc.o -MF CMakeFiles/ng-log_internal.dir/src/vlog_is_on.cc.o.d -o CMakeFiles/ng-log_internal.dir/src/vlog_is_on.cc.o -c /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/vlog_is_on.cc
[5/41] /Library/Developer/CommandLineTools/usr/bin/c++ -DGFLAGS_IS_A_DLL=0 -DNGLOG_NO_SYMBOLIZE_DETECTION -DNGLOG_STATIC_DEFINE -DNGLOG_USE_EXPORT -DNGLOG_USE_GFLAGS -I/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src -I/Users/vcpkg/Data/b/ng-log/x64-osx-dbg -isystem /Users/vcpkg/Data/installed/x64-osx/include -fPIC -g -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk -fPIE -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT CMakeFiles/symbolize_unittest.dir/src/symbolize_unittest.cc.o -MF CMakeFiles/symbolize_unittest.dir/src/symbolize_unittest.cc.o.d -o CMakeFiles/symbolize_unittest.dir/src/symbolize_unittest.cc.o -c /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/symbolize_unittest.cc
FAILED: CMakeFiles/symbolize_unittest.dir/src/symbolize_unittest.cc.o 
/Library/Developer/CommandLineTools/usr/bin/c++ -DGFLAGS_IS_A_DLL=0 -DNGLOG_NO_SYMBOLIZE_DETECTION -DNGLOG_STATIC_DEFINE -DNGLOG_USE_EXPORT -DNGLOG_USE_GFLAGS -I/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src -I/Users/vcpkg/Data/b/ng-log/x64-osx-dbg -isystem /Users/vcpkg/Data/installed/x64-osx/include -fPIC -g -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk -fPIE -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT CMakeFiles/symbolize_unittest.dir/src/symbolize_unittest.cc.o -MF CMakeFiles/symbolize_unittest.dir/src/symbolize_unittest.cc.o.d -o CMakeFiles/symbolize_unittest.dir/src/symbolize_unittest.cc.o -c /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/symbolize_unittest.cc
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/symbolize_unittest.cc:34:
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/symbolize.h:133:1: warning: inline namespaces are a C++11 feature [-Wc++11-inline-namespace]
  133 | inline namespace tools {
      | ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/symbolize.h:146:27: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
  146 | using SymbolizeCallback = int (*)(int, void*, char*, size_t, uint64_t);
      |                           ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/symbolize.h:160:41: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
  160 | using SymbolizeOpenObjectFileCallback = int (*)(uint64_t, uint64_t&, uint64_t&,
      |                                         ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/symbolize.h:172:1: warning: inline namespaces are a C++11 feature [-Wc++11-inline-namespace]
  172 | inline namespace tools {
      | ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/symbolize.h:176:6: warning: scoped enumerations are a C++11 extension [-Wc++11-extensions]
  176 | enum class SymbolizeOptions {
      |      ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/symbolize.h:183:1: error: unknown type name 'constexpr'
  183 | constexpr SymbolizeOptions operator&(SymbolizeOptions lhs,
      | ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/symbolize.h:183:27: error: expected ';' after top level declarator
  183 | constexpr SymbolizeOptions operator&(SymbolizeOptions lhs,
      |                           ^
      |                           ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/symbolize.h:190:1: error: unknown type name 'constexpr'
  190 | constexpr SymbolizeOptions operator|(SymbolizeOptions lhs,
      | ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/symbolize.h:190:27: error: expected ';' after top level declarator
  190 | constexpr SymbolizeOptions operator|(SymbolizeOptions lhs,
      |                           ^
      |                           ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/symbolize.h:203:32: warning: use of enumeration in a nested name specifier is a C++11 extension [-Wc++11-extensions]
  203 |     SymbolizeOptions options = SymbolizeOptions::kNone);
      |                                ^
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/symbolize_unittest.cc:40:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/googletest.h:63:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:63:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/flags.h:49:
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:40:15: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   40 | using int32 = std::int32_t;
      |               ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:41:16: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   41 | using uint32 = std::uint32_t;
      |                ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:42:15: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   42 | using int64 = std::int64_t;
      |               ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:43:16: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   43 | using uint64 = std::uint64_t;
      |                ^
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/symbolize_unittest.cc:40:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/googletest.h:63:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:77:
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/log_severity.h:89:1: error: unknown type name 'constexpr'
   89 | constexpr int NUM_SEVERITIES = 4;
      | ^
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/symbolize_unittest.cc:40:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/googletest.h:63:
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:86:60: error: expected ';' at end of declaration list
   86 |   const std::chrono::system_clock::time_point& when() const noexcept {
      |                                                            ^
      |                                                            ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:473:33: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
  473 | using PrefixFormatterCallback = void (*)(std::ostream&, const LogMessage&,
      |                                 ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:560:3: warning: explicit conversion functions are a C++11 extension [-Wc++11-extensions]
  560 |   explicit operator bool() const noexcept {
      |   ^~~~~~~~
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:560:33: error: expected ';' at end of declaration list
  560 |   explicit operator bool() const noexcept {
      |                                 ^
      |                                 ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:559:53: error: member initializer 'str_' does not name a non-static data member or base class
  559 |   CheckOpString(std::unique_ptr<std::string> str) : str_(std::move(str)) {}
      |                                                     ^~~~~~~~~~~~~~~~~~~~
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:711:23: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
  711 | using _Check_string = std::string;
      |                       ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:976:23: error: unknown type name 'constexpr'
  976 | NGLOG_INLINE_VARIABLE constexpr Counter_t COUNTER{};
      |                       ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:976:42: error: expected ';' after top level declarator
  976 | NGLOG_INLINE_VARIABLE constexpr Counter_t COUNTER{};
      |                                          ^
      |                                          ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1197:24: warning: rvalue references are a C++11 extension [-Wc++11-extensions]
 1197 |     LogStream(LogStream&& other) noexcept
      |                        ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1197:33: error: expected ';' at end of declaration list
 1197 |     LogStream(LogStream&& other) noexcept
      |                                 ^
      |                                 ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1222:46: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
 1222 |     LogStream& operator=(const LogStream&) = delete;
      |                                              ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1275:16: error: expected ';' at end of declaration list
 1275 |   ~LogMessage() noexcept(false);
      |                ^
      |                ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1301:31: error: expected ';' at end of declaration list
 1301 |   LogSeverity severity() const noexcept;
      |                               ^
      |                               ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1302:19: error: expected ';' at end of declaration list
 1302 |   int line() const noexcept;
      |                   ^
      |                   ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1303:43: error: expected ';' at end of declaration list
 1303 |   const std::thread::id& thread_id() const noexcept;
      |                                           ^
      |                                           ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1304:31: error: expected ';' at end of declaration list
 1304 |   const char* fullname() const noexcept;
      |                               ^
      |                               ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1305:31: error: expected ';' at end of declaration list
 1305 |   const char* basename() const noexcept;
      |                               ^
      |                               ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1306:37: error: expected ';' at end of declaration list
 1306 |   const LogMessageTime& time() const noexcept;
      |                                     ^
      |                                     ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1308:35: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
 1308 |   LogMessage(const LogMessage&) = delete;
      |                                   ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1309:46: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
 1309 |   LogMessage& operator=(const LogMessage&) = delete;
      |                                              ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1347:34: error: expected ';' at end of declaration list
 1347 |   [[noreturn]] ~LogMessageFatal() noexcept(false);
      |                                  ^
      |                                  ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1397:64: warning: rvalue references are a C++11 extension [-Wc++11-extensions]
 1397 | T CheckNotNull(const char* file, int line, const char* names, T&& t) {
      |                                                                ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
18 warnings and 20 errors generated.
[6/41] /Library/Developer/CommandLineTools/usr/bin/c++ -DGFLAGS_IS_A_DLL=0 -DNGLOG_NO_SYMBOLIZE_DETECTION -DNGLOG_USE_EXPORT -DNGLOG_USE_GFLAGS -Dng_log_EXPORTS -I/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src -I/Users/vcpkg/Data/b/ng-log/x64-osx-dbg -I/Users/vcpkg/Data/installed/x64-osx/include -fPIC -g -std=gnu++14 -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT CMakeFiles/ng-log_internal.dir/src/flags.cc.o -MF CMakeFiles/ng-log_internal.dir/src/flags.cc.o.d -o CMakeFiles/ng-log_internal.dir/src/flags.cc.o -c /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/flags.cc
[7/41] /Library/Developer/CommandLineTools/usr/bin/c++ -DGFLAGS_IS_A_DLL=0 -DNGLOG_NO_SYMBOLIZE_DETECTION -DNGLOG_STATIC_DEFINE -DNGLOG_USE_EXPORT -DNGLOG_USE_GFLAGS -I/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src -I/Users/vcpkg/Data/b/ng-log/x64-osx-dbg -isystem /Users/vcpkg/Data/installed/x64-osx/include -fPIC -g -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk -fPIE -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT CMakeFiles/stacktrace_unittest.dir/src/stacktrace_unittest.cc.o -MF CMakeFiles/stacktrace_unittest.dir/src/stacktrace_unittest.cc.o.d -o CMakeFiles/stacktrace_unittest.dir/src/stacktrace_unittest.cc.o -c /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/stacktrace_unittest.cc
FAILED: CMakeFiles/stacktrace_unittest.dir/src/stacktrace_unittest.cc.o 
/Library/Developer/CommandLineTools/usr/bin/c++ -DGFLAGS_IS_A_DLL=0 -DNGLOG_NO_SYMBOLIZE_DETECTION -DNGLOG_STATIC_DEFINE -DNGLOG_USE_EXPORT -DNGLOG_USE_GFLAGS -I/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src -I/Users/vcpkg/Data/b/ng-log/x64-osx-dbg -isystem /Users/vcpkg/Data/installed/x64-osx/include -fPIC -g -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk -fPIE -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT CMakeFiles/stacktrace_unittest.dir/src/stacktrace_unittest.cc.o -MF CMakeFiles/stacktrace_unittest.dir/src/stacktrace_unittest.cc.o.d -o CMakeFiles/stacktrace_unittest.dir/src/stacktrace_unittest.cc.o -c /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/stacktrace_unittest.cc
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/stacktrace_unittest.cc:30:
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/stacktrace.h:70:1: warning: inline namespaces are a C++11 feature [-Wc++11-inline-namespace]
   70 | inline namespace tools {
      | ^
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/stacktrace_unittest.cc:38:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:63:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/flags.h:49:
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:40:15: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   40 | using int32 = std::int32_t;
      |               ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:41:16: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   41 | using uint32 = std::uint32_t;
      |                ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:42:15: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   42 | using int64 = std::int64_t;
      |               ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:43:16: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   43 | using uint64 = std::uint64_t;
      |                ^
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/stacktrace_unittest.cc:38:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:77:
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/log_severity.h:89:1: error: unknown type name 'constexpr'
   89 | constexpr int NUM_SEVERITIES = 4;
      | ^
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/stacktrace_unittest.cc:38:
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:86:60: error: expected ';' at end of declaration list
   86 |   const std::chrono::system_clock::time_point& when() const noexcept {
      |                                                            ^
      |                                                            ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:473:33: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
  473 | using PrefixFormatterCallback = void (*)(std::ostream&, const LogMessage&,
      |                                 ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:560:3: warning: explicit conversion functions are a C++11 extension [-Wc++11-extensions]
  560 |   explicit operator bool() const noexcept {
      |   ^~~~~~~~
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:560:33: error: expected ';' at end of declaration list
  560 |   explicit operator bool() const noexcept {
      |                                 ^
      |                                 ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:559:53: error: member initializer 'str_' does not name a non-static data member or base class
  559 |   CheckOpString(std::unique_ptr<std::string> str) : str_(std::move(str)) {}
      |                                                     ^~~~~~~~~~~~~~~~~~~~
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:711:23: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
  711 | using _Check_string = std::string;
      |                       ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:976:23: error: unknown type name 'constexpr'
  976 | NGLOG_INLINE_VARIABLE constexpr Counter_t COUNTER{};
      |                       ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:976:42: error: expected ';' after top level declarator
  976 | NGLOG_INLINE_VARIABLE constexpr Counter_t COUNTER{};
      |                                          ^
      |                                          ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1197:24: warning: rvalue references are a C++11 extension [-Wc++11-extensions]
 1197 |     LogStream(LogStream&& other) noexcept
      |                        ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1197:33: error: expected ';' at end of declaration list
 1197 |     LogStream(LogStream&& other) noexcept
      |                                 ^
      |                                 ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1222:46: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
 1222 |     LogStream& operator=(const LogStream&) = delete;
      |                                              ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1275:16: error: expected ';' at end of declaration list
 1275 |   ~LogMessage() noexcept(false);
      |                ^
      |                ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1301:31: error: expected ';' at end of declaration list
 1301 |   LogSeverity severity() const noexcept;
      |                               ^
      |                               ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1302:19: error: expected ';' at end of declaration list
 1302 |   int line() const noexcept;
      |                   ^
      |                   ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1303:43: error: expected ';' at end of declaration list
 1303 |   const std::thread::id& thread_id() const noexcept;
      |                                           ^
      |                                           ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1304:31: error: expected ';' at end of declaration list
 1304 |   const char* fullname() const noexcept;
      |                               ^
      |                               ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1305:31: error: expected ';' at end of declaration list
 1305 |   const char* basename() const noexcept;
      |                               ^
      |                               ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1306:37: error: expected ';' at end of declaration list
 1306 |   const LogMessageTime& time() const noexcept;
      |                                     ^
      |                                     ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1308:35: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
 1308 |   LogMessage(const LogMessage&) = delete;
      |                                   ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1309:46: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
 1309 |   LogMessage& operator=(const LogMessage&) = delete;
      |                                              ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1347:34: error: expected ';' at end of declaration list
 1347 |   [[noreturn]] ~LogMessageFatal() noexcept(false);
      |                                  ^
      |                                  ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1397:64: warning: rvalue references are a C++11 extension [-Wc++11-extensions]
 1397 | T CheckNotNull(const char* file, int line, const char* names, T&& t) {
      |                                                                ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1399:38: error: no member named 'make_unique' in namespace 'std'
 1399 |     LogMessageFatal(file, line, std::make_unique<std::string>(names));
      |                                 ~~~~~^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1399:61: error: expected '(' for function-style cast or type construction
 1399 |     LogMessageFatal(file, line, std::make_unique<std::string>(names));
      |                                                  ~~~~~~~~~~~^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1407:3: error: unknown type name 'constexpr'
 1407 |   constexpr void operator&(std::ostream&) const noexcept {}
      |   ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1407:48: error: expected ';' at end of declaration list
 1407 |   constexpr void operator&(std::ostream&) const noexcept {}
      |                                                ^
      |                                                ;
fatal error: too many errors emitted, stopping now [-ferror-limit=]
13 warnings and 20 errors generated.
[8/41] /Library/Developer/CommandLineTools/usr/bin/c++ -DGFLAGS_IS_A_DLL=0 -DNGLOG_NO_SYMBOLIZE_DETECTION -DNGLOG_STATIC_DEFINE -DNGLOG_USE_EXPORT -DNGLOG_USE_GFLAGS -I/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src -I/Users/vcpkg/Data/b/ng-log/x64-osx-dbg -isystem /Users/vcpkg/Data/installed/x64-osx/include -fPIC -g -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk -fPIE -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT CMakeFiles/stl_logging_unittest.dir/src/stl_logging_unittest.cc.o -MF CMakeFiles/stl_logging_unittest.dir/src/stl_logging_unittest.cc.o.d -o CMakeFiles/stl_logging_unittest.dir/src/stl_logging_unittest.cc.o -c /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/stl_logging_unittest.cc
FAILED: CMakeFiles/stl_logging_unittest.dir/src/stl_logging_unittest.cc.o 
/Library/Developer/CommandLineTools/usr/bin/c++ -DGFLAGS_IS_A_DLL=0 -DNGLOG_NO_SYMBOLIZE_DETECTION -DNGLOG_STATIC_DEFINE -DNGLOG_USE_EXPORT -DNGLOG_USE_GFLAGS -I/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src -I/Users/vcpkg/Data/b/ng-log/x64-osx-dbg -isystem /Users/vcpkg/Data/installed/x64-osx/include -fPIC -g -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk -fPIE -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT CMakeFiles/stl_logging_unittest.dir/src/stl_logging_unittest.cc.o -MF CMakeFiles/stl_logging_unittest.dir/src/stl_logging_unittest.cc.o.d -o CMakeFiles/stl_logging_unittest.dir/src/stl_logging_unittest.cc.o -c /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/stl_logging_unittest.cc
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/stl_logging_unittest.cc:40:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/googletest.h:63:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:63:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/flags.h:49:
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:40:15: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   40 | using int32 = std::int32_t;
      |               ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:41:16: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   41 | using uint32 = std::uint32_t;
      |                ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:42:15: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   42 | using int64 = std::int64_t;
      |               ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:43:16: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   43 | using uint64 = std::uint64_t;
      |                ^
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/stl_logging_unittest.cc:40:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/googletest.h:63:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:77:
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/log_severity.h:89:1: error: unknown type name 'constexpr'
   89 | constexpr int NUM_SEVERITIES = 4;
      | ^
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/stl_logging_unittest.cc:40:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/googletest.h:63:
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:86:60: error: expected ';' at end of declaration list
   86 |   const std::chrono::system_clock::time_point& when() const noexcept {
      |                                                            ^
      |                                                            ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:473:33: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
  473 | using PrefixFormatterCallback = void (*)(std::ostream&, const LogMessage&,
      |                                 ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:560:3: warning: explicit conversion functions are a C++11 extension [-Wc++11-extensions]
  560 |   explicit operator bool() const noexcept {
      |   ^~~~~~~~
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:560:33: error: expected ';' at end of declaration list
  560 |   explicit operator bool() const noexcept {
      |                                 ^
      |                                 ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:559:53: error: member initializer 'str_' does not name a non-static data member or base class
  559 |   CheckOpString(std::unique_ptr<std::string> str) : str_(std::move(str)) {}
      |                                                     ^~~~~~~~~~~~~~~~~~~~
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:711:23: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
  711 | using _Check_string = std::string;
      |                       ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:976:23: error: unknown type name 'constexpr'
  976 | NGLOG_INLINE_VARIABLE constexpr Counter_t COUNTER{};
      |                       ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:976:42: error: expected ';' after top level declarator
  976 | NGLOG_INLINE_VARIABLE constexpr Counter_t COUNTER{};
      |                                          ^
      |                                          ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1197:24: warning: rvalue references are a C++11 extension [-Wc++11-extensions]
 1197 |     LogStream(LogStream&& other) noexcept
      |                        ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1197:33: error: expected ';' at end of declaration list
 1197 |     LogStream(LogStream&& other) noexcept
      |                                 ^
      |                                 ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1222:46: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
 1222 |     LogStream& operator=(const LogStream&) = delete;
      |                                              ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1275:16: error: expected ';' at end of declaration list
 1275 |   ~LogMessage() noexcept(false);
      |                ^
      |                ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1301:31: error: expected ';' at end of declaration list
 1301 |   LogSeverity severity() const noexcept;
      |                               ^
      |                               ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1302:19: error: expected ';' at end of declaration list
 1302 |   int line() const noexcept;
      |                   ^
      |                   ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1303:43: error: expected ';' at end of declaration list
 1303 |   const std::thread::id& thread_id() const noexcept;
      |                                           ^
      |                                           ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1304:31: error: expected ';' at end of declaration list
 1304 |   const char* fullname() const noexcept;
      |                               ^
      |                               ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1305:31: error: expected ';' at end of declaration list
 1305 |   const char* basename() const noexcept;
      |                               ^
      |                               ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1306:37: error: expected ';' at end of declaration list
 1306 |   const LogMessageTime& time() const noexcept;
      |                                     ^
      |                                     ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1308:35: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
 1308 |   LogMessage(const LogMessage&) = delete;
      |                                   ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1309:46: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
 1309 |   LogMessage& operator=(const LogMessage&) = delete;
      |                                              ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1347:34: error: expected ';' at end of declaration list
 1347 |   [[noreturn]] ~LogMessageFatal() noexcept(false);
      |                                  ^
      |                                  ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1397:64: warning: rvalue references are a C++11 extension [-Wc++11-extensions]
 1397 | T CheckNotNull(const char* file, int line, const char* names, T&& t) {
      |                                                                ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1399:38: error: no member named 'make_unique' in namespace 'std'
 1399 |     LogMessageFatal(file, line, std::make_unique<std::string>(names));
      |                                 ~~~~~^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1399:61: error: expected '(' for function-style cast or type construction
 1399 |     LogMessageFatal(file, line, std::make_unique<std::string>(names));
      |                                                  ~~~~~~~~~~~^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1407:3: error: unknown type name 'constexpr'
 1407 |   constexpr void operator&(std::ostream&) const noexcept {}
      |   ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1407:48: error: expected ';' at end of declaration list
 1407 |   constexpr void operator&(std::ostream&) const noexcept {}
      |                                                ^
      |                                                ;
fatal error: too many errors emitted, stopping now [-ferror-limit=]
12 warnings and 20 errors generated.
[9/41] /Library/Developer/CommandLineTools/usr/bin/c++ -DGFLAGS_IS_A_DLL=0 -DNGLOG_NO_SYMBOLIZE_DETECTION -DNGLOG_STATIC_DEFINE -DNGLOG_USE_EXPORT -DNGLOG_USE_GFLAGS -I/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src -I/Users/vcpkg/Data/b/ng-log/x64-osx-dbg -isystem /Users/vcpkg/Data/installed/x64-osx/include -fPIC -g -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk -fPIE -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT CMakeFiles/demangle_unittest.dir/src/demangle_unittest.cc.o -MF CMakeFiles/demangle_unittest.dir/src/demangle_unittest.cc.o.d -o CMakeFiles/demangle_unittest.dir/src/demangle_unittest.cc.o -c /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/demangle_unittest.cc
FAILED: CMakeFiles/demangle_unittest.dir/src/demangle_unittest.cc.o 
/Library/Developer/CommandLineTools/usr/bin/c++ -DGFLAGS_IS_A_DLL=0 -DNGLOG_NO_SYMBOLIZE_DETECTION -DNGLOG_STATIC_DEFINE -DNGLOG_USE_EXPORT -DNGLOG_USE_GFLAGS -I/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src -I/Users/vcpkg/Data/b/ng-log/x64-osx-dbg -isystem /Users/vcpkg/Data/installed/x64-osx/include -fPIC -g -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk -fPIE -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT CMakeFiles/demangle_unittest.dir/src/demangle_unittest.cc.o -MF CMakeFiles/demangle_unittest.dir/src/demangle_unittest.cc.o.d -o CMakeFiles/demangle_unittest.dir/src/demangle_unittest.cc.o -c /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/demangle_unittest.cc
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/demangle_unittest.cc:34:
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/demangle.h:84:1: warning: inline namespaces are a C++11 feature [-Wc++11-inline-namespace]
   84 | inline namespace tools {
      | ^
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/demangle_unittest.cc:41:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/googletest.h:63:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:63:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/flags.h:49:
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:40:15: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   40 | using int32 = std::int32_t;
      |               ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:41:16: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   41 | using uint32 = std::uint32_t;
      |                ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:42:15: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   42 | using int64 = std::int64_t;
      |               ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:43:16: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   43 | using uint64 = std::uint64_t;
      |                ^
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/demangle_unittest.cc:41:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/googletest.h:63:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:77:
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/log_severity.h:89:1: error: unknown type name 'constexpr'
   89 | constexpr int NUM_SEVERITIES = 4;
      | ^
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/demangle_unittest.cc:41:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/googletest.h:63:
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:86:60: error: expected ';' at end of declaration list
   86 |   const std::chrono::system_clock::time_point& when() const noexcept {
      |                                                            ^
      |                                                            ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:473:33: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
  473 | using PrefixFormatterCallback = void (*)(std::ostream&, const LogMessage&,
      |                                 ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:560:3: warning: explicit conversion functions are a C++11 extension [-Wc++11-extensions]
  560 |   explicit operator bool() const noexcept {
      |   ^~~~~~~~
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:560:33: error: expected ';' at end of declaration list
  560 |   explicit operator bool() const noexcept {
      |                                 ^
      |                                 ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:559:53: error: member initializer 'str_' does not name a non-static data member or base class
  559 |   CheckOpString(std::unique_ptr<std::string> str) : str_(std::move(str)) {}
      |                                                     ^~~~~~~~~~~~~~~~~~~~
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:711:23: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
  711 | using _Check_string = std::string;
      |                       ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:976:23: error: unknown type name 'constexpr'
  976 | NGLOG_INLINE_VARIABLE constexpr Counter_t COUNTER{};
      |                       ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:976:42: error: expected ';' after top level declarator
  976 | NGLOG_INLINE_VARIABLE constexpr Counter_t COUNTER{};
      |                                          ^
      |                                          ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1197:24: warning: rvalue references are a C++11 extension [-Wc++11-extensions]
 1197 |     LogStream(LogStream&& other) noexcept
      |                        ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1197:33: error: expected ';' at end of declaration list
 1197 |     LogStream(LogStream&& other) noexcept
      |                                 ^
      |                                 ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1222:46: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
 1222 |     LogStream& operator=(const LogStream&) = delete;
      |                                              ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1275:16: error: expected ';' at end of declaration list
 1275 |   ~LogMessage() noexcept(false);
      |                ^
      |                ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1301:31: error: expected ';' at end of declaration list
 1301 |   LogSeverity severity() const noexcept;
      |                               ^
      |                               ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1302:19: error: expected ';' at end of declaration list
 1302 |   int line() const noexcept;
      |                   ^
      |                   ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1303:43: error: expected ';' at end of declaration list
 1303 |   const std::thread::id& thread_id() const noexcept;
      |                                           ^
      |                                           ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1304:31: error: expected ';' at end of declaration list
 1304 |   const char* fullname() const noexcept;
      |                               ^
      |                               ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1305:31: error: expected ';' at end of declaration list
 1305 |   const char* basename() const noexcept;
      |                               ^
      |                               ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1306:37: error: expected ';' at end of declaration list
 1306 |   const LogMessageTime& time() const noexcept;
      |                                     ^
      |                                     ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1308:35: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
 1308 |   LogMessage(const LogMessage&) = delete;
      |                                   ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1309:46: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
 1309 |   LogMessage& operator=(const LogMessage&) = delete;
      |                                              ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1347:34: error: expected ';' at end of declaration list
 1347 |   [[noreturn]] ~LogMessageFatal() noexcept(false);
      |                                  ^
      |                                  ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1397:64: warning: rvalue references are a C++11 extension [-Wc++11-extensions]
 1397 | T CheckNotNull(const char* file, int line, const char* names, T&& t) {
      |                                                                ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1399:38: error: no member named 'make_unique' in namespace 'std'
 1399 |     LogMessageFatal(file, line, std::make_unique<std::string>(names));
      |                                 ~~~~~^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1399:61: error: expected '(' for function-style cast or type construction
 1399 |     LogMessageFatal(file, line, std::make_unique<std::string>(names));
      |                                                  ~~~~~~~~~~~^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1407:3: error: unknown type name 'constexpr'
 1407 |   constexpr void operator&(std::ostream&) const noexcept {}
      |   ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1407:48: error: expected ';' at end of declaration list
 1407 |   constexpr void operator&(std::ostream&) const noexcept {}
      |                                                ^
      |                                                ;
fatal error: too many errors emitted, stopping now [-ferror-limit=]
13 warnings and 20 errors generated.
[10/41] /Library/Developer/CommandLineTools/usr/bin/c++ -DGFLAGS_IS_A_DLL=0 -DNGLOG_NO_SYMBOLIZE_DETECTION -DNGLOG_STATIC_DEFINE -DNGLOG_USE_EXPORT -DNGLOG_USE_GFLAGS -I/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src -I/Users/vcpkg/Data/b/ng-log/x64-osx-dbg -isystem /Users/vcpkg/Data/installed/x64-osx/include -fPIC -g -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk -fPIE -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT CMakeFiles/logging_unittest.dir/src/logging_unittest.cc.o -MF CMakeFiles/logging_unittest.dir/src/logging_unittest.cc.o.d -o CMakeFiles/logging_unittest.dir/src/logging_unittest.cc.o -c /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/logging_unittest.cc
FAILED: CMakeFiles/logging_unittest.dir/src/logging_unittest.cc.o 
/Library/Developer/CommandLineTools/usr/bin/c++ -DGFLAGS_IS_A_DLL=0 -DNGLOG_NO_SYMBOLIZE_DETECTION -DNGLOG_STATIC_DEFINE -DNGLOG_USE_EXPORT -DNGLOG_USE_GFLAGS -I/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src -I/Users/vcpkg/Data/b/ng-log/x64-osx-dbg -isystem /Users/vcpkg/Data/installed/x64-osx/include -fPIC -g -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk -fPIE -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT CMakeFiles/logging_unittest.dir/src/logging_unittest.cc.o -MF CMakeFiles/logging_unittest.dir/src/logging_unittest.cc.o.d -o CMakeFiles/logging_unittest.dir/src/logging_unittest.cc.o -c /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/logging_unittest.cc
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/logging_unittest.cc:62:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/googletest.h:63:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:63:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/flags.h:49:
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:40:15: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   40 | using int32 = std::int32_t;
      |               ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:41:16: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   41 | using uint32 = std::uint32_t;
      |                ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:42:15: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   42 | using int64 = std::int64_t;
      |               ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/types.h:43:16: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
   43 | using uint64 = std::uint64_t;
      |                ^
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/logging_unittest.cc:62:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/googletest.h:63:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:77:
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/log_severity.h:89:1: error: unknown type name 'constexpr'
   89 | constexpr int NUM_SEVERITIES = 4;
      | ^
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/logging_unittest.cc:62:
In file included from /Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/googletest.h:63:
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:86:60: error: expected ';' at end of declaration list
   86 |   const std::chrono::system_clock::time_point& when() const noexcept {
      |                                                            ^
      |                                                            ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:473:33: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
  473 | using PrefixFormatterCallback = void (*)(std::ostream&, const LogMessage&,
      |                                 ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:560:3: warning: explicit conversion functions are a C++11 extension [-Wc++11-extensions]
  560 |   explicit operator bool() const noexcept {
      |   ^~~~~~~~
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:560:33: error: expected ';' at end of declaration list
  560 |   explicit operator bool() const noexcept {
      |                                 ^
      |                                 ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:559:53: error: member initializer 'str_' does not name a non-static data member or base class
  559 |   CheckOpString(std::unique_ptr<std::string> str) : str_(std::move(str)) {}
      |                                                     ^~~~~~~~~~~~~~~~~~~~
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:711:23: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
  711 | using _Check_string = std::string;
      |                       ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:976:23: error: unknown type name 'constexpr'
  976 | NGLOG_INLINE_VARIABLE constexpr Counter_t COUNTER{};
      |                       ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:976:42: error: expected ';' after top level declarator
  976 | NGLOG_INLINE_VARIABLE constexpr Counter_t COUNTER{};
      |                                          ^
      |                                          ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1197:24: warning: rvalue references are a C++11 extension [-Wc++11-extensions]
 1197 |     LogStream(LogStream&& other) noexcept
      |                        ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1197:33: error: expected ';' at end of declaration list
 1197 |     LogStream(LogStream&& other) noexcept
      |                                 ^
      |                                 ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1222:46: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
 1222 |     LogStream& operator=(const LogStream&) = delete;
      |                                              ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1275:16: error: expected ';' at end of declaration list
 1275 |   ~LogMessage() noexcept(false);
      |                ^
      |                ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1301:31: error: expected ';' at end of declaration list
 1301 |   LogSeverity severity() const noexcept;
      |                               ^
      |                               ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1302:19: error: expected ';' at end of declaration list
 1302 |   int line() const noexcept;
      |                   ^
      |                   ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1303:43: error: expected ';' at end of declaration list
 1303 |   const std::thread::id& thread_id() const noexcept;
      |                                           ^
      |                                           ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1304:31: error: expected ';' at end of declaration list
 1304 |   const char* fullname() const noexcept;
      |                               ^
      |                               ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1305:31: error: expected ';' at end of declaration list
 1305 |   const char* basename() const noexcept;
      |                               ^
      |                               ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1306:37: error: expected ';' at end of declaration list
 1306 |   const LogMessageTime& time() const noexcept;
      |                                     ^
      |                                     ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1308:35: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
 1308 |   LogMessage(const LogMessage&) = delete;
      |                                   ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1309:46: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
 1309 |   LogMessage& operator=(const LogMessage&) = delete;
      |                                              ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1347:34: error: expected ';' at end of declaration list
 1347 |   [[noreturn]] ~LogMessageFatal() noexcept(false);
      |                                  ^
      |                                  ;
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1397:64: warning: rvalue references are a C++11 extension [-Wc++11-extensions]
 1397 | T CheckNotNull(const char* file, int line, const char* names, T&& t) {
      |                                                                ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1399:38: error: no member named 'make_unique' in namespace 'std'
 1399 |     LogMessageFatal(file, line, std::make_unique<std::string>(names));
      |                                 ~~~~~^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1399:61: error: expected '(' for function-style cast or type construction
 1399 |     LogMessageFatal(file, line, std::make_unique<std::string>(names));
      |                                                  ~~~~~~~~~~~^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1407:3: error: unknown type name 'constexpr'
 1407 |   constexpr void operator&(std::ostream&) const noexcept {}
      |   ^
/Users/vcpkg/Data/b/ng-log/src/v0.8.1-000879fc45.clean/src/ng-log/logging.h:1407:48: error: expected ';' at end of declaration list
 1407 |   constexpr void operator&(std::ostream&) const noexcept {}
      |                                                ^
      |                                                ;
fatal error: too many errors emitted, stopping now [-ferror-limit=]
12 warnings and 20 errors generated.
```

</details>

From the logs, it can be seen that on macOS, when building unit tests, the `-std=gnu++14` flag is not specified, which leads to compilation errors.

I was also able to reproduce this error at: https://github.com/myd7349/ng-log-ci/commits/main/ .

```yml
name: ng-log

on:
  push:
  pull_request:
    types: [ opened, ready_for_review, reopened, synchronize ]

env:
  BUILD_TYPE: Release
  INSTALL_PREFIX: install

jobs:
  build:
    name: build
    if: >-
      github.event.pull_request.draft == false
    runs-on: macOS-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v4

      - name: Clone ng-log
        run: |
          git clone https://github.com/ng-log/ng-log.git
          pushd ng-log
          popd
      - name: Configure
        run: >
          cmake
          -S ng-log
          -B build
          -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
          -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_PREFIX }}
          -DBUILD_EXAMPLES=ON
          -DBUILD_TESTING=ON
          -DPRINT_UNSYMBOLIZED_STACK_TRACES=OFF
          -DWITH_GFLAGS=OFF
          -DWITH_GTEST=OFF
          -DWITH_PKGCONFIG=ON
          -DWITH_SYMBOLIZE=ON
          -DWITH_TLS=ON
      - name: Build & Install
        run: |
          pushd build
          make
          popd
```

The macOS workflow in ng-log did not expose this issue, possibly because `CMAKE_CXX_STANDARD` is explicitly specified in the CI configuration file:

https://github.com/ng-log/ng-log/blob/835b0cbabb5c6cddc697673c599e37c045867c03/.github/workflows/macos.yml#L46

This PR fixes the issue by adding:

```cmake
target_compile_features(ng-log_test INTERFACE
  $<TARGET_PROPERTY:ng-log,COMPILE_FEATURES>)
```

With this change, the C++ standard specified in:

https://github.com/ng-log/ng-log/blob/835b0cbabb5c6cddc697673c599e37c045867c03/CMakeLists.txt#L410

can be propagated to `ng-log_test` target.

BTW, the compilation error in vcpkg has been temporarily worked around by adding `-DBUILD_TESTING=OFF`.

