### PR TITLE
Fix build with Bazel 9

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,8 +1,8 @@
+load(":bazel/ng-log.bzl", "nglog_library")
+
 licenses(["notice"])
 
 exports_files(["COPYING"])
-
-load(":bazel/ng-log.bzl", "nglog_library")
 
 nglog_library()
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,9 @@ module(
 )
 
 bazel_dep(name = "gflags", version = "2.2.2")
+
 bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True)
+
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_cc", version = "0.0.12")
 

--- a/bazel/example/BUILD.bazel
+++ b/bazel/example/BUILD.bazel
@@ -1,9 +1,11 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 cc_test(
     name = "main",
     size = "small",
     srcs = ["main.cc"],
     deps = [
         "//:ng-log",
-        "@gflags//:gflags",
+        "@gflags",
     ],
 )

--- a/bazel/ng-log.bzl
+++ b/bazel/ng-log.bzl
@@ -9,6 +9,9 @@
 #
 # Known issue: the namespace parameter is not supported on Win32.
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 def expand_template_impl(ctx):
     ctx.actions.expand_template(
         template = ctx.file.template,
@@ -165,10 +168,9 @@ def nglog_library(with_gflags = 1, **kwargs):
             "src/base/commandlineflags.h",
             "src/stacktrace.h",
             "src/utilities.h",
-        ]
+        ],
     )
-
-    native.cc_library(
+    cc_library(
         name = "ng-log",
         visibility = ["//visibility:public"],
         srcs = [
@@ -249,7 +251,7 @@ def nglog_library(with_gflags = 1, **kwargs):
     ]
 
     for test_name in test_list:
-        native.cc_test(
+        cc_test(
             name = test_name + "_test",
             visibility = ["//visibility:public"],
             srcs = [
@@ -269,7 +271,7 @@ def nglog_library(with_gflags = 1, **kwargs):
 
     # Workaround https://github.com/bazelbuild/bazel/issues/6337 by declaring
     # the dependencies without strip_include_prefix.
-    native.cc_library(
+    cc_library(
         name = "strip_include_prefix_hack",
         hdrs = [
             "src/ng-log/flags.h",


### PR DESCRIPTION
Fixed with `buildifier --lint=fix -r ./`