### PR TITLE
fix: honor logbuflevel when logging to stdout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -653,6 +653,18 @@ if (BUILD_TESTING AND GTest_FOUND)
 
   target_link_libraries (logging_unittest PRIVATE ng-log_test)
 
+  add_executable (logtostdout_unittest
+    src/logtostdout_unittest.cc
+  )
+
+  target_link_libraries (logtostdout_unittest PRIVATE ng-log_test)
+
+  gtest_discover_tests (logtostdout_unittest
+    TEST_PREFIX logtostdout.
+    DISCOVERY_TIMEOUT 30
+    DISCOVERY_MODE PRE_TEST
+  )
+
   add_executable (stl_logging_unittest
     src/stl_logging_unittest.cc
   )

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -733,10 +733,20 @@ static void ColoredWriteToStderrOrStdout(FILE* output, LogSeverity severity,
                               ? SeverityToColor(severity)
                               : COLOR_DEFAULT;
 
+  // Unlike stderr, stdout is typically buffered by the C runtime, so honor
+  // FLAGS_logbuflevel the same way file logging does; otherwise messages can
+  // be held back indefinitely even with buffering disabled (--logbuflevel=-1).
+  const auto maybe_flush_stdout = [is_stdout, severity, output] {
+    if (is_stdout && severity > FLAGS_logbuflevel) {
+      fflush(output);
+    }
+  };
+
   // Avoid using cerr from this module since we may get called during
   // exit code, and cerr may be partially or fully destroyed by then.
   if (COLOR_DEFAULT == color) {
     fwrite(message, len, 1, output);
+    maybe_flush_stdout();
     return;
   }
 #ifdef NGLOG_OS_WINDOWS
@@ -763,6 +773,7 @@ static void ColoredWriteToStderrOrStdout(FILE* output, LogSeverity severity,
   fwrite(message, len, 1, output);
   fprintf(output, "\033[m");  // Resets the terminal to default.
 #endif  // NGLOG_OS_WINDOWS
+  maybe_flush_stdout();
 }
 
 static void ColoredWriteToStdout(LogSeverity severity, const char* message,

--- a/src/logtostdout_unittest.cc
+++ b/src/logtostdout_unittest.cc
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2026 The ng-log contributors
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Author: Tejas Anil Nagmote
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "base/commandlineflags.h"
+#include "ng-log/logging.h"
+#include "testing_utilities.h"
+
+#ifdef NGLOG_USE_GFLAGS
+#  include <gflags/gflags.h>
+using namespace GFLAGS_NAMESPACE;
+#endif
+
+using namespace nglog;
+
+namespace {
+
+constexpr char kInfoMessage[] = "buffered info message";
+constexpr char kWarningMessage[] = "unbuffered warning message";
+
+// Restores the flags this test changes even if it exits early.
+struct StdoutFlagSaver {
+  ~StdoutFlagSaver() {
+    FLAGS_logtostdout = logtostdout_;
+    FLAGS_colorlogtostdout = colorlogtostdout_;
+    FLAGS_logbuflevel = logbuflevel_;
+  }
+
+  bool logtostdout_{FLAGS_logtostdout};
+  bool colorlogtostdout_{FLAGS_colorlogtostdout};
+  decltype(FLAGS_logbuflevel) logbuflevel_{FLAGS_logbuflevel};
+};
+
+// Reads what has actually reached the capture file so far. Unlike
+// GetCapturedTestStdout(), this does not stop the capture and therefore does
+// not fflush(3) the stream itself, which is what makes it possible to observe
+// whether ng-log flushed stdout on its own.
+std::string PeekCapturedStdout(const CapturedStream& capture) {
+  std::ifstream file{capture.filename(), std::ios::binary};
+  std::ostringstream contents;
+  contents << file.rdbuf();
+  return contents.str();
+}
+
+}  // namespace
+
+// Regression test: with stdout fully buffered, a message whose severity
+// exceeds --logbuflevel must be flushed by ng-log itself instead of lingering
+// in the stdio buffer.
+//
+// This covers the uncolored exit of ColoredWriteToStderrOrStdout(). The
+// colored exit cannot be covered from here: it is only reached when
+// LogDestination::terminal_supports_color() is true, and that is a namespace
+// scope static initialized from TERM before main() runs, so the test cannot
+// select it. Where it is reached, the Windows branch flushes unconditionally
+// anyway, so only the ANSI branch depends on the flush being applied.
+TEST(LogToStdout, HonorsLogbuflevel) {
+  const StdoutFlagSaver flag_saver;
+
+  std::string after_info;
+  std::string after_warning;
+
+  {
+    CapturedStream capture{fileno(stdout), TestTmpDir() + "/logtostdout.out"};
+
+    // stdout now refers to a regular file; make sure it is fully buffered so
+    // that messages which are not explicitly flushed stay in the stdio buffer.
+    setvbuf(stdout, nullptr, _IOFBF, BUFSIZ);
+
+    FLAGS_logtostdout = true;
+    FLAGS_colorlogtostdout = false;
+    FLAGS_logbuflevel = NGLOG_INFO;  // buffer INFO, flush WARNING and above
+
+    LOG(INFO) << kInfoMessage;
+    after_info = PeekCapturedStdout(capture);
+
+    LOG(WARNING) << kWarningMessage;
+    after_warning = PeekCapturedStdout(capture);
+
+    capture.StopCapture();
+  }
+
+  // INFO does not exceed --logbuflevel, so it stays in the stdio buffer.
+  EXPECT_THAT(after_info, testing::Not(testing::HasSubstr(kInfoMessage)));
+
+  // WARNING does, so it must have been written through. Flushing the stream
+  // also emits everything buffered before it.
+  EXPECT_THAT(after_warning, testing::HasSubstr(kWarningMessage));
+  EXPECT_THAT(after_warning, testing::HasSubstr(kInfoMessage));
+}
+
+int main(int argc, char** argv) {
+  FLAGS_colorlogtostderr = false;
+
+  // Make sure stderr is not buffered as stderr seems to be buffered
+  // on recent windows.
+  setbuf(stderr, nullptr);
+
+  testing::InitGoogleTest(&argc, argv);
+  testing::InitGoogleMock(&argc, argv);
+
+#ifdef NGLOG_USE_GFLAGS
+  ParseCommandLineFlags(&argc, &argv, true);
+#endif
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
With --logtostdout, messages were written to stdout with fwrite and never flushed. stderr is unbuffered by the C runtime, so --logtostderr shows messages immediately, but stdout is typically line- or fully-buffered (always fully buffered when redirected to a pipe or file), so messages could be held back until the buffer filled or the process exited -- even with buffering explicitly disabled via --logbuflevel=-1. Reported as https://github.com/google/glog/issues/943.

Flush stdout under the same condition file logging uses (severity > FLAGS_logbuflevel), so both destinations follow the documented flag semantics. The Windows colored-console branch already flushed unconditionally; the behavior change applies to the uncolored and ANSI-color paths.