### PR TITLE
fix: log cleaner on Windows for non-ASCII log directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -751,6 +751,11 @@ if (BUILD_TESTING)
 
   target_link_libraries (cleanup_with_relative_prefix_unittest PRIVATE ng-log_test)
 
+  add_executable (cleanup_with_non_ascii_prefix_unittest
+    src/cleanup_with_non_ascii_prefix_unittest.cc)
+
+  target_link_libraries (cleanup_with_non_ascii_prefix_unittest PRIVATE ng-log_test)
+
   set (CLEANUP_LOG_DIR ${ng-log_BINARY_DIR}/cleanup_tests)
 
   add_test (NAME cleanup_init COMMAND
@@ -777,6 +782,12 @@ if (BUILD_TESTING)
     -DTEST_SUBDIR=test_subdir/
     -P ${ng-log_SOURCE_DIR}/cmake/RunCleanerTest3.cmake
     WORKING_DIRECTORY ${ng-log_BINARY_DIR})
+  add_test (NAME cleanup_with_non_ascii_prefix COMMAND
+    ${CMAKE_COMMAND}
+    -DLOGCLEANUP=$<TARGET_FILE:cleanup_with_non_ascii_prefix_unittest>
+    -DTEST_DIR=${ng-log_BINARY_DIR}/
+    -P ${ng-log_SOURCE_DIR}/cmake/RunCleanerTest4.cmake
+    WORKING_DIRECTORY ${ng-log_BINARY_DIR})
 
   # Fixtures setup
   set_tests_properties (cleanup_init PROPERTIES FIXTURES_SETUP logcleanuptest)
@@ -786,6 +797,7 @@ if (BUILD_TESTING)
   set_tests_properties (cleanup_immediately PROPERTIES FIXTURES_REQUIRED logcleanuptest)
   set_tests_properties (cleanup_with_absolute_prefix PROPERTIES FIXTURES_REQUIRED logcleanuptest)
   set_tests_properties (cleanup_with_relative_prefix PROPERTIES FIXTURES_REQUIRED logcleanuptest)
+  set_tests_properties (cleanup_with_non_ascii_prefix PROPERTIES FIXTURES_REQUIRED logcleanuptest)
 
   add_executable (striplog0_unittest
     src/striplog_unittest.cc

--- a/cmake/RunCleanerTest4.cmake
+++ b/cmake/RunCleanerTest4.cmake
@@ -1,0 +1,39 @@
+set (RUNS 3)
+
+# NOTE The log directory whose name contains non-ASCII characters is created
+# by the unit test itself: on Windows the directory name is encoded using the
+# ANSI code page, which does not necessarily match the UTF-8 encoding of this
+# script. For the same reason, the directory is matched using a wildcard
+# instead of spelling out its name.
+
+foreach (iter RANGE 1 ${RUNS})
+  execute_process (COMMAND ${LOGCLEANUP} -log_dir=${TEST_DIR}
+    RESULT_VARIABLE _RESULT)
+
+  if (NOT _RESULT EQUAL 0)
+    message (FATAL_ERROR "Failed to run logcleanup_unittest (error: ${_RESULT})")
+  endif (NOT _RESULT EQUAL 0)
+endforeach (iter)
+
+file (GLOB LOG_FILES ${TEST_DIR}/cleanup_*_dir/test_cleanup_*.nonasciifoo)
+list (LENGTH LOG_FILES NUM_FILES)
+
+if (WIN32)
+  # On Windows open files cannot be removed and will result in a permission
+  # denied error while unlinking such file. Therefore, the last file will be
+  # retained.
+  set (_expected 1)
+ else (WIN32)
+  set (_expected 0)
+endif (WIN32)
+
+if (NOT NUM_FILES EQUAL _expected)
+  message (SEND_ERROR "Expected ${_expected} log file in log directory but found ${NUM_FILES}")
+endif (NOT NUM_FILES EQUAL _expected)
+
+# Remove the directory created by the unit test.
+file (GLOB _LOG_DIRS ${TEST_DIR}/cleanup_*_dir)
+
+if (_LOG_DIRS)
+  file (REMOVE_RECURSE ${_LOG_DIRS})
+endif (_LOG_DIRS)

--- a/src/cleanup_with_non_ascii_prefix_unittest.cc
+++ b/src/cleanup_with_non_ascii_prefix_unittest.cc
@@ -1,0 +1,116 @@
+// Copyright (c) 2026, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <string>
+
+#include "base/commandlineflags.h"
+#include "googletest.h"
+#include "ng-log/logging.h"
+#include "ng-log/raw_logging.h"
+
+#ifdef NGLOG_OS_WINDOWS
+#  include <direct.h>
+#else
+#  include <sys/stat.h>
+#  include <sys/types.h>
+#endif
+
+#ifdef NGLOG_USE_GFLAGS
+#  include <gflags/gflags.h>
+using namespace GFLAGS_NAMESPACE;
+#endif
+
+#ifdef HAVE_LIB_GMOCK
+#  include <gmock/gmock.h>
+
+using testing::InitGoogleMock;
+#endif
+
+using namespace nglog;
+
+// The directory name deliberately contains non-ASCII characters to exercise
+// the multi-byte to wide character path conversions performed by the log
+// cleaner on Windows (see https://github.com/google/glog/issues/786). The
+// bytes correspond to U+20AC (euro sign) in UTF-8. The directory is created
+// here instead of by the test driver so that its name is encoded consistently
+// with the narrow character strings the logging library passes to the
+// operating system.
+constexpr const char kLogDir[] = "cleanup_\xE2\x82\xAC_dir";
+
+static void MakeLogDir(const char* name) {
+#ifdef NGLOG_OS_WINDOWS
+  _mkdir(name);
+#else
+  mkdir(name, 0777);
+#endif
+}
+
+TEST(CleanImmediatelyWithNonAsciiPrefix, logging) {
+  using namespace std::chrono_literals;
+  MakeLogDir(kLogDir);
+  nglog::EnableLogCleaner(0h);
+  nglog::SetLogFilenameExtension(".nonasciifoo");
+  nglog::SetLogDestination(NGLOG_INFO,
+                           (std::string(kLogDir) + "/test_cleanup_").c_str());
+
+  for (unsigned i = 0; i < 1000; ++i) {
+    LOG(INFO) << "cleanup test";
+  }
+
+  nglog::DisableLogCleaner();
+}
+
+int main(int argc, char** argv) {
+  FLAGS_colorlogtostderr = false;
+  FLAGS_timestamp_in_logfile_name = true;
+#ifdef NGLOG_USE_GFLAGS
+  ParseCommandLineFlags(&argc, &argv, true);
+#endif
+  // Make sure stderr is not buffered as stderr seems to be buffered
+  // on recent windows.
+  setbuf(stderr, nullptr);
+
+  // Test some basics before InitializeLogging:
+  CaptureTestStderr();
+  const string early_stderr = GetCapturedTestStderr();
+
+  EXPECT_FALSE(IsLoggingInitialized());
+
+  InitializeLogging(argv[0]);
+
+  EXPECT_TRUE(IsLoggingInitialized());
+
+  InitGoogleTest(&argc, argv);
+#ifdef HAVE_LIB_GMOCK
+  InitGoogleMock(&argc, argv);
+#endif
+
+  // so that death tests run before we use threads
+  CHECK_EQ(RUN_ALL_TESTS(), 0);
+}

--- a/src/windows/dirent.h
+++ b/src/windows/dirent.h
@@ -931,92 +931,71 @@ static int versionsort(const struct dirent** a, const struct dirent** b) {
   return alphasort(a, b);
 }
 
-/* Convert multi-byte string to wide character string */
+/*
+ * Convert multi-byte string to wide character string.
+ *
+ * The conversion deliberately uses the Windows ANSI code page (CP_ACP)
+ * instead of the locale-dependent mbstowcs: the multi-byte paths handled
+ * here are produced and consumed by the ANSI variants of the CRT and Win32
+ * file functions, which always use the ANSI code page regardless of the C
+ * locale. Under the default "C" locale, mbstowcs mangles any non-ASCII
+ * character, which made opendir() fail on such paths (see
+ * https://github.com/google/glog/issues/786).
+ */
 static int dirent_mbstowcs_s(size_t* pReturnValue, wchar_t* wcstr,
                              size_t sizeInWords, const char* mbstr,
                              size_t count) {
-  int error;
-
-#if defined(_MSC_VER) && _MSC_VER >= 1400
-
-  /* Microsoft Visual Studio 2005 or later */
-  error = mbstowcs_s(pReturnValue, wcstr, sizeInWords, mbstr, count);
-
-#else
-
-  /* Older Visual Studio or non-Microsoft compiler */
-  size_t n;
-
-  /* Convert to wide-character string (or count characters) */
-  n = mbstowcs(wcstr, mbstr, sizeInWords);
-  if (!wcstr || n < count) {
-    /* Zero-terminate output buffer */
-    if (wcstr && sizeInWords) {
-      if (n >= sizeInWords) {
-        n = sizeInWords - 1;
-      }
-      wcstr[n] = 0;
-    }
-
-    /* Length of resulting multi-byte string WITH zero terminator */
-    if (pReturnValue) {
-      *pReturnValue = n + 1;
-    }
-
-    /* Success */
-    error = 0;
-
-  } else {
+  /* Convert to wide-character string (or only compute the required size if
+   * the output buffer is nullptr).  A non-positive result indicates an
+   * invalid multi-byte sequence or an insufficient output buffer.
+   */
+  int n = MultiByteToWideChar(CP_ACP, MB_ERR_INVALID_CHARS, mbstr, -1, wcstr,
+                              wcstr ? static_cast<int>(sizeInWords) : 0);
+  if (n <= 0) {
     /* Could not convert string */
-    error = 1;
+    return 1;
   }
 
-#endif
-  return error;
+  /* Length of resulting wide-character string WITH zero terminator */
+  if (pReturnValue) {
+    *pReturnValue = static_cast<size_t>(n);
+  }
+
+  static_cast<void>(count);
+  return 0;
 }
 
-/* Convert wide-character string to multi-byte string */
+/*
+ * Convert wide-character string to multi-byte string.
+ *
+ * Uses the Windows ANSI code page for the same reason as
+ * dirent_mbstowcs_s() above.  The conversion fails for file names that
+ * cannot be represented in the ANSI code page (instead of silently picking
+ * a replacement character) so that callers can fall back to the 8.3 short
+ * name.
+ */
 static int dirent_wcstombs_s(size_t* pReturnValue, char* mbstr,
                              size_t sizeInBytes, /* max size of mbstr */
                              const wchar_t* wcstr, size_t count) {
-  int error;
-
-#if defined(_MSC_VER) && _MSC_VER >= 1400
-
-  /* Microsoft Visual Studio 2005 or later */
-  error = wcstombs_s(pReturnValue, mbstr, sizeInBytes, wcstr, count);
-
-#else
-
-  /* Older Visual Studio or non-Microsoft compiler */
-  size_t n;
-
-  /* Convert to multi-byte string (or count the number of bytes needed) */
-  n = wcstombs(mbstr, wcstr, sizeInBytes);
-  if (!mbstr || n < count) {
-    /* Zero-terminate output buffer */
-    if (mbstr && sizeInBytes) {
-      if (n >= sizeInBytes) {
-        n = sizeInBytes - 1;
-      }
-      mbstr[n] = '\0';
-    }
-
-    /* Length of resulting multi-bytes string WITH zero-terminator */
-    if (pReturnValue) {
-      *pReturnValue = n + 1;
-    }
-
-    /* Success */
-    error = 0;
-
-  } else {
+  /* Convert to multi-byte string (or only compute the required size if the
+   * output buffer is nullptr).
+   */
+  BOOL used_default_char = FALSE;
+  int n = WideCharToMultiByte(CP_ACP, WC_NO_BEST_FIT_CHARS, wcstr, -1, mbstr,
+                              mbstr ? static_cast<int>(sizeInBytes) : 0,
+                              nullptr, &used_default_char);
+  if (n <= 0 || used_default_char) {
     /* Cannot convert string */
-    error = 1;
+    return 1;
   }
 
-#endif
-  return error;
+  /* Length of resulting multi-byte string WITH zero terminator */
+  if (pReturnValue) {
+    *pReturnValue = static_cast<size_t>(n);
+  }
+
+  static_cast<void>(count);
+  return 0;
 }
 
 /* Set errno variable */


### PR DESCRIPTION
The bundled Windows dirent shim converted paths between multi-byte and wide-character strings with mbstowcs/wcstombs, which depend on the C locale. ng-log never calls setlocale, so under the default "C" locale any log directory containing characters whose Unicode code point differs from their ANSI byte value (e.g. CJK, or 0x80-0x9F in cp1252) was mangled during conversion. opendir() then looked for a directory that does not exist, and LogCleaner::GetOverdueLogNames() silently returned nothing, so EnableLogCleaner() never removed overdue logs from such directories. Reported against glog as
https://github.com/google/glog/issues/786.

Convert with MultiByteToWideChar/WideCharToMultiByte on CP_ACP instead. This is locale-independent and matches the encoding used by the ANSI CRT and Win32 file APIs that create the log files in the first place. The wide-to-narrow direction rejects unrepresentable file names (WC_NO_BEST_FIT_CHARS plus the default-character check) so readdir() keeps falling back to the 8.3 short name as before.