### PR TITLE
fix: omit default format line from header with custom prefix formatter

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1223,17 +1223,22 @@ void LogFileObject::Write(
         file_header_stream << "Application fingerprint: "
                            << g_application_fingerprint << '\n';
       }
-      const char* const date_time_format = FLAGS_log_year_in_prefix
-                                               ? "yyyymmdd hh:mm:ss.uuuuuu"
-                                               : "mmdd hh:mm:ss.uuuuuu";
       file_header_stream
           << "Running duration (h:mm:ss): "
           << PrettyDuration(
                  std::chrono::duration_cast<std::chrono::duration<int>>(
                      timestamp - start_time_))
-          << '\n'
-          << "Log line format: [IWEF]" << date_time_format << " "
-          << "threadid file:line] msg" << '\n';
+          << '\n';
+      // The hardcoded format line only describes the default prefix; with a
+      // user-installed prefix formatter the actual line format is unknown
+      // here, so advertising the default one would be wrong.
+      if (g_prefix_formatter == nullptr) {
+        const char* const date_time_format = FLAGS_log_year_in_prefix
+                                                 ? "yyyymmdd hh:mm:ss.uuuuuu"
+                                                 : "mmdd hh:mm:ss.uuuuuu";
+        file_header_stream << "Log line format: [IWEF]" << date_time_format
+                           << " threadid file:line] msg" << '\n';
+      }
       const string& file_header_string = file_header_stream.str();
 
       const size_t header_len = file_header_string.size();

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -113,6 +113,7 @@ static void TestSTREQ();
 static void TestMaxLogSizeWhenNoTimestamp();
 static void TestBasename();
 static void TestBasenameAppendWhenNoTimestamp();
+static void TestHeaderFormatLineWithCustomPrefixFormatter();
 static void TestTwoProcessesWrite();
 static void TestSymlink();
 static void TestExtension();
@@ -292,6 +293,7 @@ int main(int argc, char** argv) {
   TestMaxLogSizeWhenNoTimestamp();
   TestBasename();
   TestBasenameAppendWhenNoTimestamp();
+  TestHeaderFormatLineWithCustomPrefixFormatter();
   TestTwoProcessesWrite();
   TestSymlink();
   TestExtension();
@@ -808,6 +810,19 @@ static void CheckFile(const string& name, const string& expected_string,
              << expected_string << " in " << files[0];
 }
 
+// Check that a string is not contained anywhere in a file
+static void CheckNotInFile(const string& name, const string& unexpected) {
+  vector<string> files;
+  GetFiles(name + "*", &files);
+  CHECK_EQ(files.size(), 1UL);
+
+  std::unique_ptr<std::FILE> file{fopen(files[0].c_str(), "r")};
+  CHECK(file != nullptr) << ": could not open " << files[0];
+  const string content = ReadEntireFile(file.get());
+  CHECK(content.find(unexpected) == string::npos)
+      << ": found " << unexpected << " in " << files[0];
+}
+
 static void TestMaxLogSizeWhenNoTimestamp() {
   fprintf(stderr, "==== Test setting max log size without timestamp\n");
   const string dest = FLAGS_test_tmpdir + "/logging_test_max_log_size";
@@ -888,6 +903,46 @@ static void TestBasenameAppendWhenNoTimestamp() {
   // if the logging overwrites the file instead of appending it will fail.
   CheckFile(dest, "test preexisting content");
   CheckFile(dest, "message to new base, appending to preexisting file");
+
+  // Release file handle for the destination file to unlock the file in Windows.
+  LogToStderr();
+  DeleteFiles(dest + "*");
+}
+
+static void TestHeaderFormatLineWithCustomPrefixFormatter() {
+  fprintf(stderr, "==== Test log file header format line\n");
+  const string dest = FLAGS_test_tmpdir + "/logging_test_header_format_line";
+  DeleteFiles(dest + "*");
+
+  const bool saved_timestamp_in_logfile_name = FLAGS_timestamp_in_logfile_name;
+  FLAGS_timestamp_in_logfile_name = false;
+
+  // A custom prefix formatter is installed (see main). It determines the
+  // actual log line format, so the header must not advertise the default
+  // format.
+  SetLogDestination(NGLOG_INFO, dest.c_str());
+  LOG(INFO) << "header with custom prefix formatter";
+  FlushLogFiles(NGLOG_INFO);
+  CheckFile(dest, "Running duration (h:mm:ss):");  // the header was written
+  CheckNotInFile(dest, "Log line format: ");
+
+  // Release file handle for the destination file to unlock the file in Windows.
+  LogToStderr();
+  DeleteFiles(dest + "*");
+
+  // Without a custom prefix formatter the header advertises the default
+  // format.
+  InstallPrefixFormatter(nullptr);
+  SetLogDestination(NGLOG_INFO, dest.c_str());
+  LOG(INFO) << "header with default prefix";
+  FlushLogFiles(NGLOG_INFO);
+  CheckFile(dest, "Log line format: [IWEF]");
+
+  // Restore the prefix formatter installed by main.
+  static string prefix_attacher_data = "good data";
+  InstallPrefixFormatter(&PrefixAttacher, &prefix_attacher_data);
+
+  FLAGS_timestamp_in_logfile_name = saved_timestamp_in_logfile_name;
 
   // Release file handle for the destination file to unlock the file in Windows.
   LogToStderr();


### PR DESCRIPTION
Fixes the ng-log occurrence of https://github.com/google/glog/issues/1139 (google/glog is archived; the code is unchanged here).

## Problem

The log file header always advertises the default prefix layout:

```
Log line format: [IWEF]yyyymmdd hh:mm:ss.uuuuuu threadid file:line] msg
```

even when the application installs its own formatter via `InstallPrefixFormatter()`. In that case the actual line format is user-defined and the advertised one is simply wrong (the reporter's example: the header promises a `threadid` column that never appears).

## Fix

Only write the `Log line format:` line when no custom prefix formatter is installed. We cannot know the custom format, so omitting the line is the only truthful option. The rest of the header (creation time, machine, fingerprint, running duration) is unchanged, as is the header for the default formatter. `g_prefix_formatter` is read under the same locking regime as the existing read in `LogMessage::Init()` (both execute with `log_mutex` held).

## Verification (Windows 11, GCC 15.2 / MinGW-w64)

A program run twice, with and without `InstallPrefixFormatter()`:

- default: header contains the `Log line format:` line (unchanged);
- custom formatter: line is absent, remaining header intact, log lines use the custom prefix.

`logging_unittest`, `stl_logging_unittest`, `utilities_unittest`, and `cleanup_immediately_unittest` pass.
