### PR TITLE
fix: accept boolean WITH_UNWIND values again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,27 @@ option (WITH_TLS "Enable Thread Local Storage (TLS) support" ON)
 set (WITH_UNWIND libunwind CACHE STRING "unwind driver")
 set_property (CACHE WITH_UNWIND PROPERTY STRINGS none unwind libunwind)
 
+# Before 0.7.1, WITH_UNWIND was a boolean option. Map legacy boolean values
+# onto the none/unwind/libunwind enumeration so that build scripts written
+# for older versions keep working: false disables unwind support entirely,
+# true selects the default driver.
+string (TOLOWER "${WITH_UNWIND}" _WITH_UNWIND_LOWER)
+if (_WITH_UNWIND_LOWER MATCHES "^(none|unwind|libunwind)$")
+  # Accept any capitalization of the documented values.
+  set (WITH_UNWIND ${_WITH_UNWIND_LOWER})
+elseif (WITH_UNWIND)
+  message (DEPRECATION "boolean WITH_UNWIND value '${WITH_UNWIND}' is "
+    "deprecated; assuming WITH_UNWIND=libunwind. Use one of none, unwind, "
+    "or libunwind instead.")
+  set (WITH_UNWIND libunwind)
+else ()
+  message (DEPRECATION "boolean WITH_UNWIND value '${WITH_UNWIND}' is "
+    "deprecated; assuming WITH_UNWIND=none. Use one of none, unwind, or "
+    "libunwind instead.")
+  set (WITH_UNWIND none)
+endif ()
+unset (_WITH_UNWIND_LOWER)
+
 cmake_dependent_option (WITH_GMOCK "Use Google Mock" ON WITH_GTEST OFF)
 
 set (WITH_FUZZING none CACHE STRING "Fuzzing engine")


### PR DESCRIPTION
Fixes #27

## Problem

Before 0.7.1, `WITH_UNWIND` was a boolean `option()`. Since it became a `none`/`unwind`/`libunwind` enumeration, build scripts that still pass the old boolean values break silently: `-DWITH_UNWIND=OFF` no longer matches the `none` branch, so unwind support is probed and linked anyway — the opposite of what the caller asked for.

## Fix

As proposed in the issue, legacy boolean values are now mapped onto the enumeration with a `DEPRECATION` message: false constants (`OFF`, `0`, `FALSE`, …) behave as `none`; true values select the default driver (`libunwind`). The documented enumeration values are additionally accepted case-insensitively so that e.g. `WITH_UNWIND=NONE` (which CMake would treat as a *true* boolean, since it is not a false constant) is not misinterpreted.

## Verification

Configured with each of: default, `OFF`, `ON`, `0`, `FALSE`, `none`, `NONE`, `unwind`, `libunwind` (CMake 4.1.0, Ninja, GCC 15.2/MinGW-w64):

| value | deprecation msg | Unwind probe runs |
|---|---|---|
| default / `unwind` / `libunwind` | no | yes (unchanged) |
| `none` / `NONE` | no | no |
| `OFF` / `0` / `FALSE` | yes | no (behaves as `none`) |
| `ON` | yes | yes (behaves as `libunwind`) |

All configurations complete successfully and a full build passes with the default configuration.
