### PR TITLE
fix(signalhandler): avoid deadlock when the handler is reentered

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,8 @@ check_cxx_symbol_exists (pread unistd.h HAVE_PREAD)
 check_cxx_symbol_exists (pwrite unistd.h HAVE_PWRITE)
 check_cxx_symbol_exists (sigaction csignal HAVE_SIGACTION)
 check_cxx_symbol_exists (sigaltstack csignal HAVE_SIGALTSTACK)
+check_cxx_symbol_exists (sched_yield sched.h HAVE_SCHED_YIELD)
+check_cxx_symbol_exists (nanosleep ctime HAVE_NANOSLEEP)
 
 check_cxx_symbol_exists (backtrace execinfo.h HAVE_EXECINFO_BACKTRACE)
 check_cxx_symbol_exists (backtrace_symbols execinfo.h
@@ -721,6 +723,16 @@ if (BUILD_TESTING)
 
   if (TARGET signalhandler_unittest)
     add_test (NAME signalhandler COMMAND signalhandler_unittest)
+
+    if (HAVE_SIGACTION)
+      # Forks off the segv, reentrant, and multithread scenarios below
+      # and checks each is killed by the expected signal within a
+      # timeout, catching the reentrancy guard hanging the process
+      # instead of letting it die.
+      add_test (NAME signalhandler_self_test
+        COMMAND signalhandler_unittest self_test)
+      set_tests_properties (signalhandler_self_test PROPERTIES TIMEOUT 60)
+    endif (HAVE_SIGACTION)
   endif (TARGET signalhandler_unittest)
 
   if (TARGET stacktrace_unittest)

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -46,6 +46,12 @@
 /* Define if you have the `sigaltstack' function */
 #cmakedefine HAVE_SIGALTSTACK
 
+/* Define if you have the `sched_yield' function */
+#cmakedefine HAVE_SCHED_YIELD
+
+/* Define if you have the `nanosleep' function */
+#cmakedefine HAVE_NANOSLEEP
+
 /* Define to 1 if you have the <syscall.h> header file. */
 #cmakedefine HAVE_SYSCALL_H
 

--- a/src/signalhandler.cc
+++ b/src/signalhandler.cc
@@ -33,10 +33,10 @@
 // Implementation of InstallFailureSignalHandler().
 
 #include <algorithm>
+#include <atomic>
 #include <csignal>
 #include <cstring>
 #include <ctime>
-#include <mutex>
 #include <sstream>
 #include <thread>
 
@@ -60,6 +60,14 @@
 #  include <sys/syscall.h>
 #  include <sys/types.h>
 #endif
+#ifdef NGLOG_OS_WINDOWS
+#  include <windows.h>
+#else  // !defined(NGLOG_OS_WINDOWS)
+#  include <pthread.h>
+#  ifdef HAVE_SCHED_YIELD
+#    include <sched.h>
+#  endif  // defined(HAVE_SCHED_YIELD)
+#endif    // defined(NGLOG_OS_WINDOWS)
 
 namespace nglog {
 
@@ -288,11 +296,83 @@ void InvokeDefaultSignalHandler(int signal_number) {
 #endif
 }
 
-// This variable is used for protecting FailureSignalHandler() from dumping
-// stuff while another thread is doing it.  Our policy is to let the first
-// thread dump stuff and let other threads do nothing.
-// See also comments in FailureSignalHandler().
-static std::once_flag signaled;
+// Identifies a thread for the reentrancy guard below. Kept default-
+// constructible and otherwise trivial, unlike a typical factory-built
+// value type, so the thread_local instance below needs no signal-unsafe
+// dynamic initialization. Current() is the only way to obtain a value
+// that actually identifies a thread.
+class FailureSignalThreadId {
+ public:
+  static FailureSignalThreadId Current() noexcept {
+    FailureSignalThreadId id;
+#ifdef NGLOG_OS_WINDOWS
+    id.id_ = GetCurrentThreadId();
+#else   // !defined(NGLOG_OS_WINDOWS)
+    id.id_ = pthread_self();
+#endif  // defined(NGLOG_OS_WINDOWS)
+    return id;
+  }
+
+  friend bool operator==(const FailureSignalThreadId& lhs,
+                         const FailureSignalThreadId& rhs) noexcept {
+#ifdef NGLOG_OS_WINDOWS
+    return lhs.id_ == rhs.id_;
+#else   // !defined(NGLOG_OS_WINDOWS)
+    return pthread_equal(lhs.id_, rhs.id_) != 0;
+#endif  // defined(NGLOG_OS_WINDOWS)
+  }
+
+ private:
+#ifdef NGLOG_OS_WINDOWS
+  DWORD id_;
+#else   // !defined(NGLOG_OS_WINDOWS)
+  pthread_t id_;
+#endif  // defined(NGLOG_OS_WINDOWS)
+};
+
+// One instance per thread, alive for that thread's whole lifetime. A
+// pointer to it stays valid to dereference even after the publishing
+// call to FailureSignalHandler() has returned. See g_entered_thread_id
+// below.
+thread_local FailureSignalThreadId t_failure_signal_thread_id;
+
+// Gives up the rest of the current scheduling quantum. Used only by
+// threads spinning to be killed, so promptness doesn't matter. Only
+// sleep() is on the POSIX async-signal-safe list, but the others used
+// here are thin, state-free syscalls on every platform ng-log targets.
+void RelinquishTimeSlice() {
+#ifdef NGLOG_OS_WINDOWS
+  SwitchToThread();
+#elif defined(HAVE_SCHED_YIELD)  // !defined(NGLOG_OS_WINDOWS)
+  sched_yield();
+#elif defined(HAVE_NANOSLEEP)    // !defined(HAVE_SCHED_YIELD)
+  const struct timespec zero_duration = {};
+  nanosleep(&zero_duration, nullptr);
+#else                            // !defined(HAVE_NANOSLEEP)
+  sleep(1);
+#endif                           // defined(NGLOG_OS_WINDOWS)
+}
+
+// Id of the thread currently dumping, or nullptr. The first thread in
+// dumps. Later entrants, on any thread, wait to die. Deliberately not a
+// std::call_once() or std::once_flag. Those are not async-signal-safe,
+// and a thread reentering one while already holding it would deadlock
+// instead of dying. See also FailureSignalHandler() below.
+static std::atomic<FailureSignalThreadId*> g_entered_thread_id{nullptr};
+// is_always_lock_free needs C++17, so ATOMIC_POINTER_LOCK_FREE == 2, its
+// standard-mandated "always lock-free" equivalent, covers this ng-log
+// target's C++14 floor.
+#if defined(__cpp_lib_atomic_is_always_lock_free)
+constexpr bool kEnteredThreadIdIsLockFree =
+    decltype(g_entered_thread_id)::is_always_lock_free;
+#else   // !defined(__cpp_lib_atomic_is_always_lock_free)
+constexpr bool kEnteredThreadIdIsLockFree = ATOMIC_POINTER_LOCK_FREE == 2;
+#endif  // defined(__cpp_lib_atomic_is_always_lock_free)
+// A lock-based atomic could take a lock already held by the very thread
+// its own signal interrupted, deadlocking instead of dying.
+static_assert(kEnteredThreadIdIsLockFree,
+              "g_entered_thread_id must be lock-free to be "
+              "async-signal-safe");
 
 static void HandleSignal(int signal_number
 #if !defined(NGLOG_OS_WINDOWS)
@@ -346,7 +426,10 @@ static void HandleSignal(int signal_number
   // causes problems.
   FlushLogFilesUnsafe(NGLOG_INFO);
 
-  // Kill ourself by the default signal handler.
+  // Kill ourself by the default signal handler. Must return afterwards.
+  // signal_number stays blocked on this thread until we do, since we
+  // have no SA_NODEFER, so spinning here would keep the just-reraised
+  // signal pending forever instead of letting it kill the process.
   InvokeDefaultSignalHandler(signal_number);
 }
 
@@ -359,10 +442,34 @@ void FailureSignalHandler(int signal_number, siginfo_t* signal_info,
                           void* ucontext)
 #endif
 {
-  std::call_once(signaled, &HandleSignal, signal_number
+  t_failure_signal_thread_id = FailureSignalThreadId::Current();
+  FailureSignalThreadId* other_thread_id = nullptr;
+  // Release ordering on success publishes this thread's id to whichever
+  // thread later reads it back with acquire ordering on the failure path
+  // below, possibly on another thread.
+  if (!g_entered_thread_id.compare_exchange_strong(
+          other_thread_id, &t_failure_signal_thread_id,
+          std::memory_order_release, std::memory_order_acquire)) {
+    if (*other_thread_id == t_failure_signal_thread_id) {
+      // Reentered on this thread, likely because dumping raised another
+      // signal. Don't retry, just die. Must return, not spin, afterwards
+      // for the same reason as in HandleSignal() above. signal_number is
+      // still blocked here until we do.
+      InvokeDefaultSignalHandler(signal_number);
+      return;
+    }
+    // Another thread is dumping and will terminate the process. Spin
+    // rather than return, so this thread doesn't resume possibly
+    // corrupted execution in the meantime.
+    while (true) {
+      RelinquishTimeSlice();
+    }
+  }
+
+  HandleSignal(signal_number
 #if !defined(NGLOG_OS_WINDOWS)
-                 ,
-                 signal_info, ucontext
+               ,
+               signal_info, ucontext
 #endif
   );
 }

--- a/src/signalhandler_unittest.cc
+++ b/src/signalhandler_unittest.cc
@@ -1,4 +1,5 @@
 // Copyright (c) 2024, Google Inc.
+// Copyright (c) 2026, The ng-log contributors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -32,20 +33,27 @@
 // This is a helper binary for testing signalhandler.cc.  The actual test
 // is done in signalhandler_unittest.sh.
 
+#include <atomic>
+#include <chrono>
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>
+#include <initializer_list>
 #include <sstream>
 #include <string>
 #include <thread>
 
 #include "config.h"
 #include "ng-log/logging.h"
+#include "ng-log/platform.h"
 #include "stacktrace.h"
 #include "symbolize.h"
 
 #if defined(HAVE_UNISTD_H)
 #  include <unistd.h>
+#endif
+#if !defined(NGLOG_OS_WINDOWS)
+#  include <sys/wait.h>
 #endif
 #ifdef NGLOG_USE_GFLAGS
 #  include <gflags/gflags.h>
@@ -71,6 +79,87 @@ static void WriteToStdout(const char* data, size_t size) {
     // Ignore errors.
   }
 }
+
+// The first time this runs, it crashes again with a different signal
+// while the first crash is still being dumped.
+static void WriteAndReenter(const char* data, size_t size) {
+  if (write(fileno(stderr), data, size) < 0) {
+    // Ignore errors.
+  }
+  static std::atomic_flag entered = ATOMIC_FLAG_INIT;
+  if (!entered.test_and_set()) {
+    raise(SIGTERM);
+  }
+}
+
+static void CrashInThread() {
+  volatile int* ptr = nullptr;
+  *ptr = 0;
+}
+
+#if !defined(NGLOG_OS_WINDOWS)
+// Runs self_path with child_command as its only argument and checks
+// that the child terminates by one of acceptable_signals within
+// timeout_seconds. Used to verify the reentrancy guard in
+// signalhandler.cc actually lets the process die instead of hanging.
+// More than one acceptable signal matters whenever a second signal can
+// legitimately fire while the first is still being dumped, whether
+// deliberately (the reentrant scenario) or as a side effect of dumping
+// itself (some platforms hit an internal abort() while symbolizing a
+// std::thread-invoked frame). Once both handler invocations have
+// returned, two pending unblocked signals race, and which one the
+// kernel ends up delivering first is platform-dependent, not a
+// correctness property of the guard. The child's own stdout and stderr
+// are left connected to this process's, so a crash dump shows up
+// directly in the test log alongside the diagnostics below.
+static bool ExpectChildDiesBySignal(
+    const char* self_path, const char* child_command,
+    std::initializer_list<int> acceptable_signals, int timeout_seconds) {
+  pid_t pid = fork();
+  if (pid == 0) {
+    execl(self_path, self_path, child_command, static_cast<char*>(nullptr));
+    _exit(127);
+  }
+  if (pid < 0) {
+    fprintf(stderr, "%s: fork failed\n", child_command);
+    return false;
+  }
+
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(timeout_seconds);
+  int status = 0;
+  bool reaped = false;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (waitpid(pid, &status, WNOHANG) == pid) {
+      reaped = true;
+      break;
+    }
+    usleep(20000);
+  }
+  if (!reaped) {
+    fprintf(stderr, "%s: timed out after %d seconds\n", child_command,
+            timeout_seconds);
+    kill(pid, SIGKILL);
+    waitpid(pid, &status, 0);
+    return false;
+  }
+  if (WIFSIGNALED(status)) {
+    for (int signal : acceptable_signals) {
+      if (WTERMSIG(status) == signal) {
+        return true;
+      }
+    }
+    fprintf(stderr, "%s: died by unexpected signal %d\n", child_command,
+            WTERMSIG(status));
+  } else if (WIFEXITED(status)) {
+    fprintf(stderr, "%s: exited with code %d instead of dying by a signal\n",
+            child_command, WEXITSTATUS(status));
+  } else {
+    fprintf(stderr, "%s: unexpected status 0x%x\n", child_command, status);
+  }
+  return false;
+}
+#endif  // !defined(NGLOG_OS_WINDOWS)
 
 int main(int argc, char** argv) {
 #if defined(HAVE_STACKTRACE) && defined(HAVE_SYMBOLIZE)
@@ -99,6 +188,29 @@ int main(int argc, char** argv) {
   } else if (command == "installed") {
     fprintf(stderr, "signal handler installed: %s\n",
             IsFailureSignalHandlerInstalled() ? "true" : "false");
+  } else if (command == "reentrant") {
+    InstallFailureWriter(&WriteAndReenter);
+    abort();
+  } else if (command == "multithread") {
+    std::thread t1{&CrashInThread};
+    std::thread t2{&CrashInThread};
+    std::thread t3{&CrashInThread};
+    std::thread t4{&CrashInThread};
+    t1.join();
+    t2.join();
+    t3.join();
+    t4.join();
+#  if !defined(NGLOG_OS_WINDOWS)
+  } else if (command == "self_test") {
+    const bool ok =
+        ExpectChildDiesBySignal(argv[0], "segv", {SIGSEGV}, 10) &&
+        ExpectChildDiesBySignal(argv[0], "reentrant", {SIGTERM, SIGABRT},
+                                10) &&
+        ExpectChildDiesBySignal(argv[0], "multithread", {SIGSEGV, SIGABRT},
+                                10);
+    puts(ok ? "OK" : "FAIL");
+    return ok ? 0 : 1;
+#  endif  // !defined(NGLOG_OS_WINDOWS)
   } else {
     // Tell the shell script
     puts("OK");


### PR DESCRIPTION
FailureSignalHandler() guarded against concurrent dumps with std::call_once(), which is not async-signal-safe. A failure signal raised while the handler was already dumping on the same thread will wait forever on the once flag held by that very thread, hanging the process instead of letting it die.

Replace the guard with an atomic entered-thread ID. The first thread dumps, other threads sleep until the process dies, and reentry on the same thread kills the process via the default handler immediately. This also lets stack traces unwind past the handler, since the std::call_once() machinery no longer sits between the handler and the crashed frames.

Originally reported in google/glog#1080.