### PR TITLE
fix(demangle): terminate output and fail on truncation

### DIFF
--- a/src/demangle.cc
+++ b/src/demangle.cc
@@ -1,4 +1,5 @@
 // Copyright (c) 2024, Google Inc.
+// Copyright (c) 2026, The ng-log contributors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -37,7 +38,9 @@
 #include "demangle.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdlib>
+#include <cstring>
 #include <limits>
 
 #include "utilities.h"
@@ -1351,12 +1354,28 @@ bool Demangle(const char* mangled, char* out, size_t out_size) {
   std::unique_ptr<char, decltype(&std::free)> unmangled{
       abi::__cxa_demangle(mangled, nullptr, &n, &status), &std::free};
 
-  if (!unmangled) {
+  if (!unmangled || status != 0) {
     return false;
   }
 
-  std::copy_n(unmangled.get(), std::min(n, out_size), out);
-  return status == 0;
+  // n is the size of the buffer __cxa_demangle() allocated, not the length of
+  // the demangled name. A name that does not fit is a failure, not a success
+  // with the name silently cut off.
+  const auto* end =
+      static_cast<const char*>(std::memchr(unmangled.get(), '\0', n));
+
+  if (end == nullptr) {
+    return false;
+  }
+
+  const std::ptrdiff_t length = end - unmangled.get() + 1;
+
+  if (static_cast<std::size_t>(length) > out_size) {
+    return false;
+  }
+
+  std::copy_n(unmangled.get(), length, out);
+  return true;
 #else
   State state;
   InitState(&state, mangled, out, out_size);

--- a/src/demangle_unittest.cc
+++ b/src/demangle_unittest.cc
@@ -1,4 +1,5 @@
 // Copyright (c) 2006, Google Inc.
+// Copyright (c) 2026, The ng-log contributors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -138,6 +139,41 @@ TEST(Demangle, CtorDtorTruncation) {
       "_ZN7ppppppppppsppppppppppppppppppppppppppppppppppppppI00000E0SiD22L_"
       "ZTVZleA2_ZZ\x7f";
   EXPECT_FALSE(Demangle(fuzzed, tmp2, sizeof(tmp2)));
+}
+
+// A name whose demangled form does not fit the output buffer must be
+// reported as a failure, not as a success with the output silently cut
+// off, and in particular must never leave the output unterminated: the
+// crash handler demangles the frames of a dumped stack trace into a
+// fixed-size buffer, and an unterminated "success" previously made it
+// abort (and then hang) in the middle of dumping. The symbol below is
+// std::call_once()'s execution machinery, which is part of every such
+// stack trace, and demangles to well over 256 characters.
+TEST(Demangle, LongNameTruncation) {
+  const char* const mangled =
+      "_ZZNSt9once_flag18_Prepare_executionC1IZSt9call_onceIPFviP9siginfo_t"
+      "PvEJRiRS4_RS5_EEvRS_OT_DpOT0_EUlvE_EERSC_ENKUlvE_clEv";
+
+  // Large enough for any implementation to succeed, in which case the
+  // result must be '\0'-terminated.
+  char big[4096];
+  if (Demangle(mangled, big, sizeof(big))) {
+    EXPECT_LT(strnlen(big, sizeof(big)), sizeof(big));
+  }
+
+  char small_buf[256];
+#  if defined(HAVE___CXA_DEMANGLE)
+  // abi::__cxa_demangle() produces the full name, including template
+  // arguments, which cannot fit: this must fail rather than truncate.
+  EXPECT_FALSE(Demangle(mangled, small_buf, sizeof(small_buf)));
+#  else   // !defined(HAVE___CXA_DEMANGLE)
+  // Other implementations may abbreviate (e.g. the fallback demangler
+  // omits template arguments) and legitimately fit, but a reported
+  // success must still be '\0'-terminated.
+  if (Demangle(mangled, small_buf, sizeof(small_buf))) {
+    EXPECT_LT(strnlen(small_buf, sizeof(small_buf)), sizeof(small_buf));
+  }
+#  endif  // defined(HAVE___CXA_DEMANGLE)
 }
 
 TEST(Demangle, FromFile) {

--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -86,10 +86,18 @@ ATTRIBUTE_NOINLINE
 void DemangleInplace(char* out, size_t out_size) {
   char demangled[256];  // Big enough for sane demangled symbols.
   if (Demangle(out, demangled, sizeof(demangled))) {
-    // Demangling succeeded. Copy to out if the space allows.
-    size_t len = strlen(demangled);
+    // Demangling succeeded. Copy to out if the space allows. The scan is
+    // bounded (std::memchr() rather than strlen(); strnlen() is POSIX,
+    // not standard C++) so that a Demangle() implementation which breaks
+    // its contract (reporting success without '\0'-terminating the
+    // output) trips the assertion below instead of the scan reading past
+    // the buffer.
+    const void* const terminator =
+        std::memchr(demangled, '\0', sizeof(demangled));
+    NGLOG_SAFE_ASSERT(terminator != nullptr);
+    const size_t len =
+        static_cast<size_t>(static_cast<const char*>(terminator) - demangled);
     if (len + 1 <= out_size) {  // +1 for '\0'.
-      NGLOG_SAFE_ASSERT(len < sizeof(demangled));
       memmove(out, demangled, len + 1);
     }
   }


### PR DESCRIPTION
The abi::__cxa_demangle() based implementation reported success for names longer than the output buffer while leaving the output without a terminator, and copied the allocation size rather than the name itself. Demangling such a name from the crash handler made DemangleInplace() abort in the middle of dumping a stack trace.

A name that does not fit is now a failure, and DemangleInplace() scans the result with a bound so a broken contract cannot cause undefined behavior.