### PR TITLE
fix: avoid blocking concurrent writers during posix_fadvise

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1103,7 +1103,7 @@ bool LogFileObject::CreateLogfile(const string& time_pid_string) {
 void LogFileObject::Write(
     bool force_flush, const std::chrono::system_clock::time_point& timestamp,
     const char* message, size_t message_len) {
-  std::lock_guard<std::mutex> l{mutex_};
+  std::unique_lock<std::mutex> l{mutex_};
 
   // We don't log if the base_name_ is "" (which means "don't write")
   if (base_filename_selected_ && base_filename_.empty()) {
@@ -1283,11 +1283,37 @@ void LogFileObject::Write(
       if (this_drop_length >= (2U << 20U)) {
         // Only advise when >= 2MiB to drop
 #  if defined(HAVE_POSIX_FADVISE)
-        posix_fadvise(
-            fileno(file_.get()), static_cast<off_t>(dropped_mem_length_),
-            static_cast<off_t>(this_drop_length), POSIX_FADV_DONTNEED);
-#  endif
+        const off_t offset = static_cast<off_t>(dropped_mem_length_);
+        const off_t length = static_cast<off_t>(this_drop_length);
+
+        // Advance the bookkeeping before releasing the lock so that
+        // concurrent writers do not recompute overlapping drop ranges and
+        // a rollover while the lock is released keeps its freshly reset
+        // accounting.
         dropped_mem_length_ = total_drop_length;
+
+        // posix_fadvise() can block for a substantial amount of time (e.g.,
+        // due to kernel-internal LRU draining or writeback under I/O
+        // pressure). Duplicate the descriptor and release mutex_ while the
+        // syscall runs so that other threads logging to this file are not
+        // serialized behind it. The duplicate keeps the underlying open
+        // file description alive even if this file gets rolled over while
+        // the lock is released and preserves the close-on-exec flag set on
+        // the original descriptor.
+        FileDescriptor fd{fcntl(fileno(file_.get()), F_DUPFD_CLOEXEC, 0)};
+        if (fd) {
+          l.unlock();
+          posix_fadvise(fd.get(), offset, length, POSIX_FADV_DONTNEED);
+          l.lock();
+        } else {
+          // Duplicating the descriptor failed. Fall back to advising while
+          // holding the lock.
+          posix_fadvise(fileno(file_.get()), offset, length,
+                        POSIX_FADV_DONTNEED);
+        }
+#  else
+        dropped_mem_length_ = total_drop_length;
+#  endif
       }
     }
 #endif

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -121,6 +121,7 @@ static void TestErrno();
 static void TestTruncate();
 static void TestCustomLoggerDeletionOnShutdown();
 static void TestLogPeriodically();
+static void TestDropLogMemoryConcurrentWriters();
 
 static int x = -1;
 static void BM_Check1(int n) {
@@ -298,6 +299,7 @@ int main(int argc, char** argv) {
   TestWrapper();
   TestErrno();
   TestTruncate();
+  TestDropLogMemoryConcurrentWriters();
   TestCustomLoggerDeletionOnShutdown();
   TestLogPeriodically();
 
@@ -1105,6 +1107,71 @@ static void TestTruncate() {
   TestOneTruncate(fdpath, 10, 10, 10, 10, 10);
 #  endif
 
+#endif
+}
+
+static void TestDropLogMemoryConcurrentWriters() {
+#if defined(NGLOG_OS_LINUX) && defined(HAVE_POSIX_FADVISE)
+  fprintf(stderr,
+          "==== Test concurrent writers while drop_log_memory triggers "
+          "posix_fadvise\n");
+  const std::string dest = FLAGS_test_tmpdir + "/logging_test_drop_log_memory";
+  DeleteFiles(dest + "*");
+
+  const bool old_drop_log_memory = FLAGS_drop_log_memory;
+  const int32 old_logbufsecs = FLAGS_logbufsecs;
+  // Force every write to flush and re-evaluate the drop_log_memory
+  // threshold, so that posix_fadvise() is exercised multiple times while
+  // other threads are concurrently appending to the same log file.
+  FLAGS_drop_log_memory = true;
+  FLAGS_logbufsecs = 0;
+
+  SetLogDestination(NGLOG_INFO, dest.c_str());
+
+  constexpr int kThreads = 8;
+  constexpr int kMessagesPerThread = 400;
+  const std::string filler(3000, 'x');
+
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&filler] {
+      for (int i = 0; i < kMessagesPerThread; ++i) {
+        LOG(INFO) << filler;
+      }
+    });
+  }
+  // The writers repeatedly exercise the path that releases the per-file
+  // mutex around posix_fadvise(). Joining verifies that this does not
+  // deadlock. The checks below verify that no messages were lost or torn.
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  FlushLogFiles(NGLOG_INFO);
+
+  // None of the concurrently written messages should have been lost or
+  // corrupted by unlocking mutex_ around posix_fadvise().
+  std::vector<std::string> filenames;
+  GetFiles(dest + "*", &filenames);
+  CHECK_EQ(filenames.size(), 1UL);
+
+  std::ifstream file(filenames[0]);
+  CHECK(file.is_open()) << ": could not open " << filenames[0];
+  int line_count = 0;
+  for (std::string line; std::getline(file, line);) {
+    if (line.find(filler) != std::string::npos) {
+      ++line_count;
+    }
+  }
+  CHECK_EQ(line_count, kThreads * kMessagesPerThread);
+
+  // Release file handle for the destination file to unlock the file in
+  // Windows.
+  LogToStderr();
+  DeleteFiles(dest + "*");
+  FLAGS_drop_log_memory = old_drop_log_memory;
+  FLAGS_logbufsecs = old_logbufsecs;
 #endif
 }
 


### PR DESCRIPTION
posix_fadvise(POSIX_FADV_DONTNEED) can reportedly stall under I/O pressure or kernel LRU draining. LogFileObject::Write() called it while holding the per-file mutex, so every thread logging at that severity queued up behind the syscall instead of only the thread that triggered the memory drop.

Release the mutex while posix_fadvise() runs, using a duplicated file descriptor so the call still targets the correct open file description even if another thread rotates the log file in the meantime. The duplicate is created with close-on-exec to match the original descriptor. The drop bookkeeping is advanced before the lock is released so that concurrent writers do not recompute overlapping drop ranges and a rollover during the call keeps its freshly reset accounting instead of being overwritten afterwards.

The test drives many threads writing to the same log file with drop_log_memory enabled, forcing the fadvise path to run repeatedly under concurrency, and checks that no messages are lost or corrupted.

Closes #6 