### PR TITLE
fix(signalhandler): restore LWP id in signal dumps on Linux

### DIFF
--- a/src/signalhandler.cc
+++ b/src/signalhandler.cc
@@ -230,7 +230,7 @@ void DumpSignalInfo(int signal_number, siginfo_t* siginfo) {
   std::ostringstream oss;
   oss << std::showbase << std::hex << std::this_thread::get_id();
   formatter.AppendString(oss.str().c_str());
-#  if defined(GLOG_OS_LINUX) && defined(HAVE_SYS_SYSCALL_H) && \
+#  if defined(NGLOG_OS_LINUX) && defined(HAVE_SYS_SYSCALL_H) && \
       defined(HAVE_SYS_TYPES_H)
   pid_t tid = syscall(SYS_gettid);
   formatter.AppendString(" LWP ");


### PR DESCRIPTION
@
## Problem

`DumpSignalInfo()` guards the kernel thread id (LWP) output with `GLOG_OS_LINUX`:

```cpp
#  if defined(GLOG_OS_LINUX) && defined(HAVE_SYS_SYSCALL_H) && \
      defined(HAVE_SYS_TYPES_H)
  pid_t tid = syscall(SYS_gettid);
  formatter.AppendString(" LWP ");
  formatter.AppendUint64(static_cast<uint64>(tid), 10);
#  endif
```

After the glog → ng-log rename the OS macro is `NGLOG_OS_LINUX` (defined in `platform.h`); `GLOG_OS_LINUX` is not defined anywhere in the project. The branch is therefore dead, and crash/signal dumps on Linux silently lost the `LWP <tid>` field.

The immediately following branch in the same function already uses the correct `NGLOG_OS_LINUX`, confirming the intended spelling:

```cpp
#  ifdef NGLOG_OS_LINUX
  formatter.AppendString("from PID ");
```

## Fix

Use `NGLOG_OS_LINUX` so the LWP thread id is emitted again. One-line, no behavioral change on non-Linux platforms.
@