### PR TITLE
docs: fix typos in comments and documentation

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -10,7 +10,7 @@ the build system will automatically detect and use it, allowing you to
 pass flags on the command line.
 
 !!! example "Activate `--logtostderr` in an application from the command line"
-    A binary `you_application` that uses ng-log can be started using
+    A binary `your_application` that uses ng-log can be started using
     ``` bash
     ./your_application --logtostderr=1
     ```

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -988,7 +988,7 @@ bool LogFileObject::CreateLogfile(const string& time_pid_string) {
   }
   string_filename += filename_extension_;
   const char* filename = string_filename.c_str();
-  // only write to files, create if non-existant.
+  // only write to files, create if non-existent.
   int flags = O_WRONLY | O_CREAT;
   if (FLAGS_timestamp_in_logfile_name) {
     // demand that the file is unique for our timestamp (fail if it exists).

--- a/src/raw_logging.cc
+++ b/src/raw_logging.cc
@@ -152,7 +152,7 @@ void RawLog(LogSeverity severity, const char* file, int line,
     return;  // this stderr log message is suppressed
   }
 
-  // We do not have any any option other that string streams to obtain the
+  // We do not have any option other than string streams to obtain the
   // thread identifier as the corresponding value is not convertible to an
   // integer. Use a statically allocated buffer to avoid dynamic memory
   // allocations.

--- a/src/symbolize_unittest.cc
+++ b/src/symbolize_unittest.cc
@@ -166,7 +166,7 @@ TEST(Symbolize, SymbolizeWithDemangling) {
 // and after the signal handler returns, look at the alternate stack
 // buffer to see what portion has been touched.
 //
-// This trick gives us the the stack footprint of the signal handler.
+// This trick gives us the stack footprint of the signal handler.
 // But the signal handler, even before the call to Symbolize, consumes
 // some stack already. We however only want the stack usage of the
 // Symbolize function. To measure this accurately, we install two signal

--- a/src/vlog_is_on.cc
+++ b/src/vlog_is_on.cc
@@ -259,7 +259,7 @@ bool InitializeVLOG3(SiteFlag* site_flag, int32* level_default,
     // If VLOG flag has been cached to the default site pointer,
     // we want to add to the cached list in order to invalidate in case
     // SetVModule is called afterwards with new modules.
-    // The performance penalty here is neglible, because InitializeVLOG3 is
+    // The performance penalty here is negligible, because InitializeVLOG3 is
     // called once per site.
     if (site_flag_value == level_default && !site_flag->base_name) {
       site_flag->base_name = base;


### PR DESCRIPTION
@
Corrects a few typos found while reading through the sources and docs. Comment/docs only, no functional change.

Code comments:
- `logging.cc`: "non-existant" → "non-existent"
- `raw_logging.cc`: "any any option other that" → "any option other than" (doubled word + wrong preposition)
- `vlog_is_on.cc`: "neglible" → "negligible"
- `symbolize_unittest.cc`: "the the stack footprint" → "the stack footprint" (doubled word)

Documentation:
- `docs/flags.md`: "you_application" → "your_application" (matches the surrounding command examples)
@