### PR TITLE
fix(cmake): use ng-log version variable in config version guard

### DIFF
--- a/ng-log-config.cmake.in
+++ b/ng-log-config.cmake.in
@@ -1,5 +1,5 @@
 if (CMAKE_VERSION VERSION_LESS @ng-log_CMake_VERSION@)
-  message (FATAL_ERROR "CMake >= @glog_CMake_VERSION@ required")
+  message (FATAL_ERROR "CMake >= @ng-log_CMake_VERSION@ required")
 endif (CMAKE_VERSION VERSION_LESS @ng-log_CMake_VERSION@)
 
 @PACKAGE_INIT@


### PR DESCRIPTION
@
## Problem

The installed package config `ng-log-config.cmake.in` guards against too-old CMake:

```cmake
if (CMAKE_VERSION VERSION_LESS @ng-log_CMake_VERSION@)
  message (FATAL_ERROR "CMake >= @glog_CMake_VERSION@ required")
endif (CMAKE_VERSION VERSION_LESS @ng-log_CMake_VERSION@)
```

The `VERSION_LESS` comparisons use `@ng-log_CMake_VERSION@`, but the error **message** still references `@glog_CMake_VERSION@` — a leftover from the glog → ng-log rename. `CMakeLists.txt` only ever sets `ng-log_CMake_VERSION` (to `3.0`/`3.9`), so `glog_CMake_VERSION` is undefined and the placeholder expands to an empty string.

A downlevel-CMake consumer running `find_package(ng-log)` would therefore see:

```
CMake >=  required
```

with the required version missing.

## Fix

Use `@ng-log_CMake_VERSION@` in the message so it matches the version actually being checked. Config-template-only change.
@