### PR TITLE
fix: cap oversized max_log_size instead of shrinking it to 1 MB

### DIFF
--- a/src/flags.cc
+++ b/src/flags.cc
@@ -132,7 +132,8 @@ NGLOG_DEFINE_string(log_link, "",
 
 NGLOG_DEFINE_uint32(max_log_size, 1800,
                     "approx. maximum log file size (in MB). A value of 0 will "
-                    "be silently overridden to 1.");
+                    "be silently overridden to 1. Values above 4095 are capped "
+                    "to 4095.");
 
 NGLOG_DEFINE_bool(stop_logging_if_full_disk, false,
                   "Stop attempting to log to disk if the disk is full.");

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -272,11 +272,16 @@ static const char* GetAnsiColorCode(GLogColor color) {
 
 #endif  // NGLOG_OS_WINDOWS
 
-// Safely get max_log_size, overriding to 1 if it somehow gets defined as 0
+// Safely get max_log_size. A value of 0 is overridden to the 1 MB minimum.
+// Values large enough to overflow the "MaxLogSize() << 20" byte computation
+// are capped to the 4095 MB maximum instead of being silently reduced to the
+// minimum, which would produce surprisingly tiny log files.
 static uint32 MaxLogSize() {
-  return (FLAGS_max_log_size > 0 && FLAGS_max_log_size < 4096
-              ? FLAGS_max_log_size
-              : 1);
+  constexpr uint32 max_megabytes = 4095;  // 4095 << 20 fits in a uint32.
+  if (FLAGS_max_log_size == 0) {
+    return 1;
+  }
+  return FLAGS_max_log_size < max_megabytes ? FLAGS_max_log_size : max_megabytes;
 }
 
 // An arbitrary limit on the length of a single log message.  This

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -111,6 +111,7 @@ static void TestCHECK();
 static void TestDCHECK();
 static void TestSTREQ();
 static void TestMaxLogSizeWhenNoTimestamp();
+static void TestMaxLogSizeAboveCapNotFlooredToMinimum();
 static void TestBasename();
 static void TestBasenameAppendWhenNoTimestamp();
 static void TestTwoProcessesWrite();
@@ -291,6 +292,7 @@ int main(int argc, char** argv) {
   FLAGS_logtostdout = false;
 
   TestMaxLogSizeWhenNoTimestamp();
+  TestMaxLogSizeAboveCapNotFlooredToMinimum();
   TestBasename();
   TestBasenameAppendWhenNoTimestamp();
   TestTwoProcessesWrite();
@@ -843,6 +845,46 @@ static void TestMaxLogSizeWhenNoTimestamp() {
            FLAGS_max_log_size << 20U);
 
   // Reset flag values to their original values
+  FLAGS_max_log_size = original_max_log_size;
+  FLAGS_timestamp_in_logfile_name = original_timestamp_in_logfile_name;
+
+  // Release file handle for the destination file to unlock the file in Windows.
+  LogToStderr();
+  DeleteFiles(dest + "*");
+}
+
+static void TestMaxLogSizeAboveCapNotFlooredToMinimum() {
+  fprintf(stderr, "==== Test max log size above the cap is not floored to 1MB\n");
+  const string dest =
+      FLAGS_test_tmpdir + "/logging_test_max_log_size_above_cap";
+  DeleteFiles(dest + "*");
+
+  auto original_max_log_size = FLAGS_max_log_size;
+  auto original_timestamp_in_logfile_name = FLAGS_timestamp_in_logfile_name;
+
+  // A value larger than the 4095MB cap used to be clamped to the 1MB minimum,
+  // which would rotate the file after ~1MB. It must instead be capped to the
+  // maximum, so the file is allowed to grow past 1MB without rotating.
+  FLAGS_max_log_size = 8000;
+  FLAGS_timestamp_in_logfile_name = false;
+
+  SetLogDestination(NGLOG_INFO, dest.c_str());
+
+  // 20000 info logs -> around 1.5MB, i.e. comfortably above 1MB. If the
+  // oversized limit were (incorrectly) floored to 1MB, earlier logs would be
+  // truncated and the resulting file would stay below 1MB.
+  constexpr int num_logs = 20'000;
+  for (int i = 0; i < num_logs; i++) {
+    LOG(INFO) << "Hello world";
+  }
+  FlushLogFiles(NGLOG_INFO);
+
+  struct stat statbuf;
+  stat(dest.c_str(), &statbuf);
+
+  // No rotation at 1MB should have happened, so the file exceeds 1MB.
+  CHECK_GT(static_cast<unsigned int>(statbuf.st_size), 1U << 20U);
+
   FLAGS_max_log_size = original_max_log_size;
   FLAGS_timestamp_in_logfile_name = original_timestamp_in_logfile_name;
 


### PR DESCRIPTION
## Problem

`MaxLogSize()` collapses any out-of-range value to the 1 MB minimum:

```cpp
static uint32 MaxLogSize() {
  return (FLAGS_max_log_size > 0 && FLAGS_max_log_size < 4096
              ? FLAGS_max_log_size
              : 1);
}
```

The `< 4096` bound is needed because the size is later used as `MaxLogSize() << 20` (MB to bytes) in a `uint32`, and `4096 << 20` overflows. But sending oversized values to the *minimum* means a user who sets, e.g., `--max_log_size=8000` silently gets **1 MB** log files instead of large ones -- the opposite of the intent. It also contradicts the flag documentation, which only states that a value of 0 is overridden to 1.

## Fix

Cap oversized values at the 4095 MB maximum (`4095 << 20` still fits in a `uint32`) while keeping the `0 -> 1` override. Values in [1, 4095] are unchanged; only values >= 4096 change (from 1 to 4095). The flag help text is updated to document the cap.

## Test

Adds `TestMaxLogSizeAboveCapNotFlooredToMinimum`, mirroring the existing `TestMaxLogSizeWhenNoTimestamp`: it sets `max_log_size=8000`, writes ~1.5 MB of logs, and asserts the file grows past 1 MB. Against the old code the oversized value was floored to 1 MB, the file rotated below 1 MB, and this check fails.