### PR TITLE
test: make missing-capture diagnostics reachable

### DIFF
--- a/src/testing_utilities.cc
+++ b/src/testing_utilities.cc
@@ -222,9 +222,11 @@ void PrintDiff(const std::vector<std::string>& golden,
 // Get the captured stdout or stderr as a string
 std::string GetCapturedTestOutput(int fd) {
   CHECK((fd == fileno(stdout)) || (fd == fileno(stderr)));
-  std::unique_ptr<CapturedStream> cap = std::move(s_captured_streams.at(fd));
-  s_captured_streams.erase(fd);
-  CHECK(cap) << ": did you forget CaptureTestStdout() or CaptureTestStderr()?";
+  auto pos = s_captured_streams.find(fd);
+  CHECK(pos != s_captured_streams.end())
+      << ": did you forget CaptureTestStdout() or CaptureTestStderr()?";
+  std::unique_ptr<CapturedStream> cap = std::move(pos->second);
+  s_captured_streams.erase(pos);
 
   // Make sure everything is flushed.
   cap->StopCapture();
@@ -329,14 +331,6 @@ std::string Munge(const std::string& filename) {
 }
 
 bool MungeAndDiffTest(const std::string& golden_filename, CapturedStream* cap) {
-  auto pos = s_captured_streams.find(fileno(stdout));
-
-  if (pos != s_captured_streams.end() && cap == pos->second.get()) {
-    CHECK(cap) << ": did you forget CaptureTestStdout()?";
-  } else {
-    CHECK(cap) << ": did you forget CaptureTestStderr()?";
-  }
-
   cap->StopCapture();
 
   // Run munge
@@ -371,13 +365,17 @@ std::string GetCapturedTestStderr() {
 }
 
 bool MungeAndDiffTestStdout(const std::string& golden_filename) {
-  return MungeAndDiffTest(golden_filename,
-                          s_captured_streams.at(fileno(stdout)).get());
+  auto pos = s_captured_streams.find(fileno(stdout));
+  CHECK(pos != s_captured_streams.end())
+      << ": did you forget CaptureTestStdout()?";
+  return MungeAndDiffTest(golden_filename, pos->second.get());
 }
 
 bool MungeAndDiffTestStderr(const std::string& golden_filename) {
-  return MungeAndDiffTest(golden_filename,
-                          s_captured_streams.at(fileno(stderr)).get());
+  auto pos = s_captured_streams.find(fileno(stderr));
+  CHECK(pos != s_captured_streams.end())
+      << ": did you forget CaptureTestStderr()?";
+  return MungeAndDiffTest(golden_filename, pos->second.get());
 }
 
 void (*g_new_hook)() = nullptr;


### PR DESCRIPTION
## Problem

In the new `testing_utilities.cc`, the missing-capture diagnostics are unreachable:

```cpp
std::unique_ptr<CapturedStream> cap = std::move(s_captured_streams.at(fd));
s_captured_streams.erase(fd);
CHECK(cap) << ": did you forget CaptureTestStdout() or CaptureTestStderr()?";
```

If no capture is active, `std::map::at()` throws `std::out_of_range` **before** the `CHECK` runs — and when the entry does exist, the moved-from pointer is always non-null. Either way the helpful message can never fire; misuse surfaces as an unhandled exception. The same applies to `MungeAndDiffTestStdout()`/`Stderr()` (`.at(...)` at the call site), which also makes the stdout-vs-stderr detection block inside `MungeAndDiffTest()` dead weight.

## Fix

Look the stream up with `find()` and `CHECK` the result with the correct per-stream message before touching it. `MungeAndDiffTest()` loses the redundant detection block since both callers now guarantee a non-null capture.

Test-infrastructure only; no library behavior change.