### PR TITLE
test: avoid undefined behavior in IsLoggingPrefix character checks

### DIFF
--- a/src/testing_utilities.cc
+++ b/src/testing_utilities.cc
@@ -244,9 +244,14 @@ bool IsLoggingPrefix(const std::string& s) {
   if (s.size() != kLoggingPrefixLength) {
     return false;
   }
-  if (!strchr("IWEF", s[0])) return false;
+  if (s[0] == '\0' || !strchr("IWEF", s[0])) return false;
   for (size_t i = 1; i <= 8; ++i) {
-    if (!isdigit(s[i]) && s[i] != "YEARDATE"[i - 1]) return false;
+    // Cast to unsigned char: passing a negative char (e.g. from non-ASCII
+    // log content) to isdigit() is undefined behavior.
+    if (!isdigit(static_cast<unsigned char>(s[i])) &&
+        s[i] != "YEARDATE"[i - 1]) {
+      return false;
+    }
   }
   return true;
 }


### PR DESCRIPTION
Two hardening fixes in `IsLoggingPrefix()` in the new `testing_utilities.cc`:

1. **`isdigit()` UB on negative `char`**: `isdigit(s[i])` passes a plain `char`; for bytes with the high bit set (e.g. when `Munge()` processes log lines containing non-ASCII paths, which the test suite produces on purpose) the value is negative on signed-char platforms, which is undefined behavior per [cctype] requirements. Cast to `unsigned char` first — the canonical fix (also what clang-tidy's `bugprone-narrowing-conversions`/cert-str34-c family recommends).

2. **`strchr` NUL match**: `strchr("IWEF", s[0])` returns a pointer to the search set's terminator when `s[0] == '\0'`, so a 9-char string starting with NUL was incorrectly accepted as a logging prefix. Reject NUL explicitly.

Test-infrastructure only; no library behavior change.