### PR TITLE
feat(symbolize): add libbacktrace as an optional stacktrace backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,14 +44,13 @@ set (WITH_UNWIND libunwind CACHE STRING "unwind driver")
 set_property (CACHE WITH_UNWIND PROPERTY STRINGS none unwind libunwind)
 
 # Backend for resolving file names and line numbers in symbolized stack
-# frames. "auto" uses addr2line when available; "addr2line" requires it,
-# failing the configuration otherwise is not done here, only a warning is
-# issued later once availability is known. "none" disables the feature. A
-# CMake boolean false (OFF, FALSE, 0, NO, an empty string, ...) is treated
-# the same as "none", and anything else that is not one of the three names
-# above (including a boolean true such as ON) is treated the same as
-# "auto".
-#
+# frames. "auto" uses libbacktrace when available, since it resolves
+# in-process without spawning a subprocess per frame, and falls back to
+# addr2line otherwise. "addr2line" and "libbacktrace" force one specific
+# backend. "none" disables both. A CMake boolean false (OFF, FALSE, 0, NO,
+# an empty string, ...) is treated the same as "none", and anything else
+# that is not one of the four names above (including a boolean true such
+# as ON) is treated the same as "auto".
 # When built with MinGW, "addr2line" replaces the DbgHelp-based backend
 # entirely rather than supplementing it: DbgHelp cannot read the DWARF
 # debug info a MinGW build emits by default, so addr2line resolves the
@@ -59,19 +58,13 @@ set_property (CACHE WITH_UNWIND PROPERTY STRINGS none unwind libunwind)
 # DbgHelp, since addr2line requires MinGW.
 set (WITH_LINE_INFO auto CACHE STRING
   "Backend for resolving file names and line numbers in stack traces")
-set_property (CACHE WITH_LINE_INFO PROPERTY STRINGS none auto addr2line)
+set_property (CACHE WITH_LINE_INFO PROPERTY STRINGS none auto addr2line libbacktrace)
 
 if (NOT WITH_LINE_INFO)
   set (WITH_LINE_INFO none)
-elseif (NOT WITH_LINE_INFO MATCHES "^(none|auto|addr2line)$")
+elseif (NOT WITH_LINE_INFO MATCHES "^(none|auto|addr2line|libbacktrace)$")
   set (WITH_LINE_INFO auto)
 endif (NOT WITH_LINE_INFO)
-
-if (WITH_LINE_INFO STREQUAL auto OR WITH_LINE_INFO STREQUAL addr2line)
-  set (_ng-log_try_addr2line ON)
-else (WITH_LINE_INFO STREQUAL auto OR WITH_LINE_INFO STREQUAL addr2line)
-  set (_ng-log_try_addr2line OFF)
-endif (WITH_LINE_INFO STREQUAL auto OR WITH_LINE_INFO STREQUAL addr2line)
 
 set (WITH_FUZZING none CACHE STRING "Fuzzing engine")
 set_property (CACHE WITH_FUZZING PROPERTY STRINGS none libfuzzer ossfuzz)
@@ -79,6 +72,21 @@ set_property (CACHE WITH_FUZZING PROPERTY STRINGS none libfuzzer ossfuzz)
 if (NOT WITH_UNWIND OR WITH_UNWIND STREQUAL none)
   set (CMAKE_DISABLE_FIND_PACKAGE_Unwind ON)
 endif (NOT WITH_UNWIND OR WITH_UNWIND STREQUAL none)
+
+set (_ng-log_try_addr2line OFF)
+set (_ng-log_try_libbacktrace OFF)
+
+if (WITH_LINE_INFO STREQUAL auto OR WITH_LINE_INFO STREQUAL addr2line)
+  set (_ng-log_try_addr2line ON)
+endif (WITH_LINE_INFO STREQUAL auto OR WITH_LINE_INFO STREQUAL addr2line)
+
+if (WITH_LINE_INFO STREQUAL auto OR WITH_LINE_INFO STREQUAL libbacktrace)
+  set (_ng-log_try_libbacktrace ON)
+endif (WITH_LINE_INFO STREQUAL auto OR WITH_LINE_INFO STREQUAL libbacktrace)
+
+if (NOT _ng-log_try_libbacktrace)
+  set (CMAKE_DISABLE_FIND_PACKAGE_Libbacktrace ON)
+endif (NOT _ng-log_try_libbacktrace)
 
 set (CMAKE_C_VISIBILITY_PRESET hidden)
 set (CMAKE_CXX_VISIBILITY_PRESET hidden)
@@ -107,6 +115,7 @@ endif (WITH_GFLAGS)
 
 find_package (Threads REQUIRED)
 find_package (Unwind)
+find_package (Libbacktrace)
 
 if (Unwind_FOUND)
   cmake_push_check_state (RESET)
@@ -307,6 +316,12 @@ if (WITH_SYMBOLIZE)
       set (HAVE_SYMBOLIZE 1)
       set (HAVE_ADDR2LINE 1)
       set (HAVE_STACKTRACE 1)
+    elseif (MINGW AND _ng-log_try_libbacktrace AND
+            TARGET libbacktrace::libbacktrace)
+      # Likewise, libbacktrace resolves both the symbol name and the
+      # file/line from DWARF debug info (what MinGW emits by default) via
+      # its own PE/COFF and DWARF readers, without going through DbgHelp.
+      set (HAVE_SYMBOLIZE 1)
     else (MINGW AND _ng-log_try_addr2line AND HAVE_SUBPROCESS)
       cmake_push_check_state (RESET)
       set (CMAKE_REQUIRED_LIBRARIES DbgHelp)
@@ -352,17 +367,42 @@ if (WITH_SYMBOLIZE)
   endif (WIN32 OR CYGWIN)
 endif (WITH_SYMBOLIZE)
 
-if (_ng-log_try_addr2line AND HAVE_SYMBOLIZE AND HAVE_SUBPROCESS AND UNIX AND
-    (HAVE_ELF_H OR HAVE_SYS_EXEC_ELF_H) AND HAVE_SIGACTION)
+# Excluded on Emscripten: it has no real process model, so neither
+# posix_spawn() nor fork()+exec() can actually run an addr2line subprocess
+# there, regardless of what the symbol checks below report.
+if (_ng-log_try_addr2line AND HAVE_SYMBOLIZE AND UNIX AND NOT EMSCRIPTEN AND
+    (HAVE_ELF_H OR HAVE_SYS_EXEC_ELF_H) AND HAVE_SIGACTION AND
+    HAVE_SUBPROCESS)
   set (HAVE_ADDR2LINE 1)
 endif ()
+
+if (_ng-log_try_libbacktrace AND HAVE_SYMBOLIZE AND TARGET libbacktrace::libbacktrace
+    AND (UNIX OR MINGW))
+  set (HAVE_LIBBACKTRACE 1)
+endif (_ng-log_try_libbacktrace AND HAVE_SYMBOLIZE AND
+       TARGET libbacktrace::libbacktrace AND (UNIX OR MINGW))
 
 if (WITH_LINE_INFO STREQUAL addr2line AND NOT HAVE_ADDR2LINE)
   message (WARNING "WITH_LINE_INFO is 'addr2line' but addr2line support "
     "is not available. This setting has no effect in this configuration.")
+elseif (WITH_LINE_INFO STREQUAL libbacktrace AND NOT HAVE_LIBBACKTRACE)
+  message (WARNING "WITH_LINE_INFO is 'libbacktrace' but libbacktrace "
+    "support is not available. This setting has no effect in this "
+    "configuration.")
 endif (WITH_LINE_INFO STREQUAL addr2line AND NOT HAVE_ADDR2LINE)
 
 unset (_ng-log_try_addr2line)
+unset (_ng-log_try_libbacktrace)
+
+# Both can only end up available at once when WITH_LINE_INFO is "auto" (any
+# other setting only ever tries one backend). HAVE_ADDR2LINE and
+# HAVE_LIBBACKTRACE are otherwise mutually exclusive, so utilities.cc and
+# symbolize.cc never need to reconcile the two backends themselves. Prefer
+# libbacktrace: it resolves in-process, without spawning a subprocess per
+# frame.
+if (HAVE_ADDR2LINE AND HAVE_LIBBACKTRACE)
+  unset (HAVE_ADDR2LINE)
+endif (HAVE_ADDR2LINE AND HAVE_LIBBACKTRACE)
 
 # CMake manages symbolize availability. The definition is necessary only when
 # building the library.
@@ -403,6 +443,11 @@ if (Unwind_FOUND)
   # Copy the module only if libunwind is actually used.
   list (APPEND _ng-log_CMake_MODULES ${ng-log_SOURCE_DIR}/cmake/FindUnwind.cmake)
 endif (Unwind_FOUND)
+
+if (HAVE_LIBBACKTRACE)
+  # Copy the module only if libbacktrace is actually used.
+  list (APPEND _ng-log_CMake_MODULES ${ng-log_SOURCE_DIR}/cmake/FindLibbacktrace.cmake)
+endif (HAVE_LIBBACKTRACE)
 
 # Generate file name for each module in the binary directory
 foreach (_file ${_ng-log_CMake_MODULES})
@@ -445,6 +490,8 @@ set (NGLOG_SRCS
   src/demangle.h
   src/flags.cc
   src/initializer.h
+  src/libbacktrace.cc
+  src/libbacktrace.h
   src/logging.cc
   src/raw_logging.cc
   src/signalhandler.cc
@@ -516,6 +563,12 @@ if (Unwind_FOUND)
   set (ng-log_libraries_options_for_static_linking "${ng-log_libraries_options_for_static_linking} -lunwind")
   set (Unwind_DEPENDENCY "find_dependency (Unwind ${Unwind_VERSION})")
 endif (Unwind_FOUND)
+
+if (HAVE_LIBBACKTRACE)
+  target_link_libraries (ng-log PRIVATE libbacktrace::libbacktrace)
+  set (ng-log_libraries_options_for_static_linking "${ng-log_libraries_options_for_static_linking} -lbacktrace")
+  set (Libbacktrace_DEPENDENCY "find_dependency (Libbacktrace)")
+endif (HAVE_LIBBACKTRACE)
 
 if (HAVE_DBGHELP)
   target_link_libraries (ng-log PRIVATE dbghelp)
@@ -742,6 +795,14 @@ if (BUILD_TESTING AND GTest_FOUND)
     endif (MINGW)
   endif (HAVE_SUBPROCESS)
 
+  if (HAVE_LIBBACKTRACE)
+    add_executable (libbacktrace_unittest
+      src/libbacktrace_unittest.cc
+    )
+
+    target_link_libraries (libbacktrace_unittest PRIVATE ng-log_test)
+  endif (HAVE_LIBBACKTRACE)
+
   add_executable (demangle_unittest
     src/demangle_unittest.cc
   )
@@ -875,6 +936,14 @@ if (BUILD_TESTING AND GTest_FOUND)
       DISCOVERY_MODE PRE_TEST
     )
   endif (TARGET subprocess_unittest)
+
+  if (TARGET libbacktrace_unittest)
+    gtest_discover_tests (libbacktrace_unittest
+      TEST_PREFIX libbacktrace.
+      DISCOVERY_TIMEOUT 30
+      DISCOVERY_MODE PRE_TEST
+    )
+  endif (TARGET libbacktrace_unittest)
 
   add_executable (mock-log_unittest
     src/mock-log_unittest.cc

--- a/cmake/FindLibbacktrace.cmake
+++ b/cmake/FindLibbacktrace.cmake
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 The ng-log contributors
+# SPDX-License-Identifier: BSD-3-Clause
+#
+#[=======================================================================[.rst:
+FindLibbacktrace
+----------------
+
+Finds the libbacktrace library.
+
+.. code-block:: cmake
+
+  find_package (Libbacktrace)
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported target when libbacktrace is found:
+
+``libbacktrace::libbacktrace``
+  Target that provides the include directory and library for libbacktrace.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variable:
+
+``Libbacktrace_FOUND``
+  Boolean indicating whether libbacktrace was found.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``Libbacktrace_INCLUDE_DIR``
+  The directory containing ``backtrace.h``.
+
+``Libbacktrace_LIBRARY``
+  The libbacktrace library.
+#]=======================================================================]
+
+include (FindPackageHandleStandardArgs)
+
+find_path (Libbacktrace_INCLUDE_DIR NAMES backtrace.h DOC "libbacktrace include directory")
+find_library (Libbacktrace_LIBRARY NAMES backtrace DOC "libbacktrace library")
+
+mark_as_advanced (Libbacktrace_INCLUDE_DIR Libbacktrace_LIBRARY)
+
+find_package_handle_standard_args (Libbacktrace
+  REQUIRED_VARS Libbacktrace_INCLUDE_DIR Libbacktrace_LIBRARY
+)
+
+if (Libbacktrace_FOUND)
+  if (NOT TARGET libbacktrace::libbacktrace)
+    add_library (libbacktrace::libbacktrace INTERFACE IMPORTED)
+
+    set_property (TARGET libbacktrace::libbacktrace PROPERTY
+      INTERFACE_INCLUDE_DIRECTORIES ${Libbacktrace_INCLUDE_DIR}
+    )
+    set_property (TARGET libbacktrace::libbacktrace PROPERTY
+      INTERFACE_LINK_LIBRARIES ${Libbacktrace_LIBRARY}
+    )
+  endif (NOT TARGET libbacktrace::libbacktrace)
+endif (Libbacktrace_FOUND)

--- a/docs/failures.md
+++ b/docs/failures.md
@@ -73,23 +73,37 @@ supported[^1] by ng-log.
 
 ## Resolving File Names and Line Numbers
 
-When built with `WITH_LINE_INFO` set to `auto` (the default) or
-`addr2line`, ng-log resolves the source file and line number of each
-stack frame by invoking the `addr2line` command-line tool, in addition to
-the symbol name. This applies to both the failure signal handler and
-`LOG(FATAL)`/unsatisfied `CHECK` traces. The tool is invoked as an
-external process with a bounded timeout, so a missing or unresponsive
-`addr2line` only suppresses the file and line information rather than
-affecting the rest of the crash report.
+When built with `WITH_LINE_INFO` set to `auto` (the default), `addr2line`, or
+`libbacktrace`, ng-log resolves the source file and line number of each stack
+frame, in addition to the symbol name. This applies to both the failure signal
+handler and `LOG(FATAL)`/unsatisfied `CHECK` traces. `WITH_LINE_INFO=none`
+disables the feature.
 
-When built with MinGW, `addr2line` also replaces `dbghelp` as the symbol
-resolver entirely rather than supplementing it, since `dbghelp` cannot
-read the DWARF debug information a MinGW build emits by default. MSVC
-builds always use `dbghelp`, since `addr2line` requires MinGW.
+Two backends provide this:
 
-Resolution can be disabled at runtime without recompiling by setting
-`#!cpp FLAGS_symbolize_line_info` to `false`, or `--symbolize_line_info=false`
-on the command line. The `#!cpp FLAGS_addr2line_timeout_ms` flag controls
-how long, in milliseconds, ng-log waits for `addr2line` to resolve a
-single address before giving up on it.
+* `addr2line` invokes the `addr2line` command-line tool as an external
+  process with a bounded timeout, so a missing or unresponsive
+  `addr2line` only suppresses the file and line information rather than
+  affecting the rest of the crash report.
+* `libbacktrace` resolves the symbol name and the file and line number
+  in-process, directly from the DWARF debug information, without spawning a
+  subprocess per frame. It requires the
+  [libbacktrace](https://github.com/ianlancetaylor/libbacktrace) library to be
+  available at build time.
+
+`auto` prefers `libbacktrace` when it is available and falls back to `addr2line`
+otherwise. Forcing one backend with `WITH_LINE_INFO` means the other is never
+even probed.
+
+When built with MinGW, `addr2line` or `libbacktrace` also replace `dbghelp` as
+the symbol resolver entirely rather than supplementing it, since `dbghelp`
+cannot read the DWARF debug information a MinGW build emits by default. MSVC
+builds always use `dbghelp`, since neither backend understands MSVC's mangled
+names or debug information.
+
+Resolution can be disabled at runtime without recompiling by setting `#!cpp
+FLAGS_symbolize_line_info` to `false`, or `--symbolize_line_info=false` on the
+command line. The `#!cpp FLAGS_addr2line_timeout_ms` flag controls how long, in
+milliseconds, ng-log waits for `addr2line` to resolve a single address before
+giving up on it. It has no effect when `libbacktrace` is the active backend.
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -5,7 +5,7 @@
 ### 0.9.0 <small>TBD</small> { id="0.9.0" }
 
 - Resolve source file names and line numbers in stack traces via
-  [addr2line](failures.md#resolving-file-names-and-line-numbers)
+  [`addr2line` or `libbacktrace`](failures.md#resolving-file-names-and-line-numbers)
 - Remove the glog compatibility layer
 - Remove Bazel build support
 - Prevent concurrent log writers from blocking during memory-drop maintenance

--- a/ng-log-config.cmake.in
+++ b/ng-log-config.cmake.in
@@ -11,5 +11,6 @@ find_dependency (Threads)
 
 @gflags_DEPENDENCY@
 @Unwind_DEPENDENCY@
+@Libbacktrace_DEPENDENCY@
 
 include (${CMAKE_CURRENT_LIST_DIR}/ng-log-targets.cmake)

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -119,12 +119,21 @@
 /* define if symbolize support is available */
 #cmakedefine HAVE_SYMBOLIZE
 
-/* define if addr2line-based file/line resolution is available */
+/* define if addr2line-based file/line resolution is available. Cannot be
+   combined with HAVE_LIBBACKTRACE. */
 #cmakedefine HAVE_ADDR2LINE
 
 /* define if Subprocess (src/subprocess.h) can spawn and communicate with an
    external program on this platform */
 #cmakedefine HAVE_SUBPROCESS
+
+/* define if libbacktrace-based symbolization is available. Cannot be
+   combined with HAVE_ADDR2LINE. */
+#cmakedefine HAVE_LIBBACKTRACE
+
+#if defined(HAVE_ADDR2LINE) && defined(HAVE_LIBBACKTRACE)
+#  error "HAVE_ADDR2LINE and HAVE_LIBBACKTRACE cannot both be defined"
+#endif
 
 /* define if localtime_r is available in time.h */
 #cmakedefine HAVE_LOCALTIME_R

--- a/src/demangle.cc
+++ b/src/demangle.cc
@@ -1322,7 +1322,40 @@ bool ParseTopLevelMangledName(State* state) {
 
 // The demangler entry point.
 bool Demangle(const char* mangled, char* out, size_t out_size) {
-#if defined(NGLOG_OS_WINDOWS)
+  // Checked ahead of NGLOG_OS_WINDOWS: which demangler understands "mangled"
+  // depends on the compiler's name-mangling ABI, not the target OS. MinGW
+  // and Clang on Windows use the Itanium ABI (abi::__cxa_demangle()) just
+  // like on Linux or macOS; only MSVC uses the ABI UnDecorateSymbolName()
+  // below understands.
+#if defined(HAVE___CXA_DEMANGLE)
+  int status = -1;
+  std::size_t n = 0;
+  std::unique_ptr<char, decltype(&std::free)> unmangled{
+      abi::__cxa_demangle(mangled, nullptr, &n, &status), &std::free};
+
+  if (!unmangled || status != 0) {
+    return false;
+  }
+
+  // n is the size of the buffer __cxa_demangle() allocated, not the length of
+  // the demangled name. A name that does not fit is a failure, not a success
+  // with the name silently cut off.
+  const auto* end =
+      static_cast<const char*>(std::memchr(unmangled.get(), '\0', n));
+
+  if (end == nullptr) {
+    return false;
+  }
+
+  const std::ptrdiff_t length = end - unmangled.get() + 1;
+
+  if (static_cast<std::size_t>(length) > out_size) {
+    return false;
+  }
+
+  std::copy_n(unmangled.get(), length, out);
+  return true;
+#elif defined(NGLOG_OS_WINDOWS)
 #  if defined(HAVE_DBGHELP)
   // When built with incremental linking, the Windows debugger
   // library provides a more complicated `Symbol->Name` with the
@@ -1351,34 +1384,6 @@ bool Demangle(const char* mangled, char* out, size_t out_size) {
   (void)out_size;
   return false;
 #  endif
-#elif defined(HAVE___CXA_DEMANGLE)
-  int status = -1;
-  std::size_t n = 0;
-  std::unique_ptr<char, decltype(&std::free)> unmangled{
-      abi::__cxa_demangle(mangled, nullptr, &n, &status), &std::free};
-
-  if (!unmangled || status != 0) {
-    return false;
-  }
-
-  // n is the size of the buffer __cxa_demangle() allocated, not the length of
-  // the demangled name. A name that does not fit is a failure, not a success
-  // with the name silently cut off.
-  const auto* end =
-      static_cast<const char*>(std::memchr(unmangled.get(), '\0', n));
-
-  if (end == nullptr) {
-    return false;
-  }
-
-  const std::ptrdiff_t length = end - unmangled.get() + 1;
-
-  if (static_cast<std::size_t>(length) > out_size) {
-    return false;
-  }
-
-  std::copy_n(unmangled.get(), length, out);
-  return true;
 #else
   State state;
   InitState(&state, mangled, out, out_size);

--- a/src/flags.cc
+++ b/src/flags.cc
@@ -161,7 +161,8 @@ NGLOG_DEFINE_bool(symbolize_stacktrace, true,
 
 NGLOG_DEFINE_bool(symbolize_line_info, true,
                   "Resolve file names and line numbers for symbolized "
-                  "stack frames using addr2line, if available.");
+                  "stack frames using addr2line or libbacktrace, if "
+                  "available.");
 
 NGLOG_DEFINE_int32(addr2line_timeout_ms, 2000,
                    "Upper bound in milliseconds on how long to wait for "

--- a/src/libbacktrace.cc
+++ b/src/libbacktrace.cc
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2026 The ng-log contributors
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Author: Sergiu Deitsch
+
+#include "libbacktrace.h"
+
+#ifdef HAVE_LIBBACKTRACE
+
+#  include <backtrace.h>
+
+#  include <cstdint>
+#  include <cstdio>
+#  include <mutex>
+#  include <string>
+
+#  include "ng-log/flags.h"
+#  include "symbolize.h"
+
+namespace nglog {
+inline namespace tools {
+
+namespace {
+
+// A missing symbol table or missing debug info is a routine, expected
+// condition (e.g. a stripped binary, or a module compiled without -g), not
+// something worth logging on every symbolization attempt. Only reached via
+// libbacktrace's own error path, not the ordinary "nothing found" one, so
+// nothing here exercises it: the test binaries always carry a symbol table.
+// LCOV_EXCL_START
+void ErrorCallback(void* /*data*/, const char* /*msg*/, int /*errnum*/) {}
+// LCOV_EXCL_STOP
+
+// GetBacktraceState() must always return the same state: libbacktrace has
+// no documented way to merge or discard one, so creating more than one per
+// process would just mean redundant ELF/DWARF parsing work. std::call_once
+// makes that single-creation guarantee explicit, rather than relying on a
+// function-local static's implicit (and, per frame, re-checked) guard.
+std::once_flag g_backtrace_state_once;
+backtrace_state* g_backtrace_state = nullptr;
+
+}  // namespace
+
+backtrace_state* GetBacktraceState() {
+  std::call_once(g_backtrace_state_once, [] {
+    // A nullptr filename lets libbacktrace locate the running executable
+    // itself (e.g. via /proc/self/exe on Linux). Other loaded modules are
+    // discovered on demand as addresses are looked up. threaded=1 because
+    // Symbolize() may run concurrently from multiple threads (e.g. from
+    // signal handlers on different threads).
+    g_backtrace_state = backtrace_create_state(nullptr, /*threaded=*/1,
+                                               &ErrorCallback, nullptr);
+  });
+  return g_backtrace_state;
+}
+
+std::size_t FormatLibbacktraceLocation(const char* filename, int lineno,
+                                       char* out, std::size_t out_size) {
+  if (filename == nullptr || filename[0] == '\0' || out_size == 0) {
+    return 0;
+  }
+
+  const int written = std::snprintf(out, out_size, "%s:%d ", filename, lineno);
+
+  if (written < 0 || static_cast<std::size_t>(written) >= out_size) {
+    // Truncated (or an encoding error): never return a partially written
+    // result.
+    out[0] = '\0';
+    return 0;
+  }
+
+  return static_cast<std::size_t>(written);
+}
+
+namespace {
+
+struct PcInfoContext {
+  std::string filename;
+  int lineno = 0;
+  bool found = false;
+};
+
+// Records the innermost (first) location backtrace_pcinfo() reports for a
+// pc, and returns non-zero so backtrace_pcinfo() stops there instead of
+// continuing on to any further inlined call frames.
+int PcInfoCallback(void* data, uintptr_t /*pc*/, const char* filename,
+                   int lineno, const char* /*function*/) {
+  auto* ctx = static_cast<PcInfoContext*>(data);
+  if (filename != nullptr) {
+    ctx->filename = filename;
+    ctx->lineno = lineno;
+    ctx->found = true;
+  }
+  return 1;
+}
+
+// Resolves file name and line number for "pc" via backtrace_pcinfo() and
+// writes "<file>:<line> " to "out". "fd" and "relocation" are unused:
+// unlike Addr2LineSymbolizeCallback(), which needs the object file's path
+// and load bias to build an "addr2line --exe" command line, libbacktrace
+// resolves the containing module and applies the load bias internally, from
+// the raw runtime "pc".
+int LibbacktraceSymbolizeCallback(int /*fd*/, void* pc, char* out,
+                                  std::size_t out_size,
+                                  uint64_t /*relocation*/) {
+  if (!FLAGS_symbolize_line_info) {
+    return 0;
+  }
+
+  backtrace_state* const state = GetBacktraceState();
+  if (state == nullptr) {
+    // LCOV_EXCL_START: backtrace_create_state() only fails to create a
+    // state if it cannot locate this process's own executable (e.g. no
+    // /proc/self/exe), which does not happen for a live process on the
+    // platforms this backend supports.
+    return 0;
+    // LCOV_EXCL_STOP
+  }
+
+  PcInfoContext ctx;
+  backtrace_pcinfo(state, reinterpret_cast<uintptr_t>(pc), &PcInfoCallback,
+                   &ErrorCallback, &ctx);
+
+  if (!ctx.found) {
+    return 0;
+  }
+
+  return static_cast<int>(FormatLibbacktraceLocation(
+      ctx.filename.c_str(), ctx.lineno, out, out_size));
+}
+
+}  // namespace
+
+bool InstallLibbacktraceSymbolizeCallback() {
+  InstallSymbolizeCallback(&LibbacktraceSymbolizeCallback);
+  return true;
+}
+
+}  // namespace tools
+}  // namespace nglog
+
+#endif  // HAVE_LIBBACKTRACE

--- a/src/libbacktrace.h
+++ b/src/libbacktrace.h
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 The ng-log contributors
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Author: Sergiu Deitsch
+//
+// Resolves symbol names and file names and line numbers for symbolized program
+// counters via libbacktrace, an in-process DWARF and symbol table reader.
+// symbolize.cc uses GetBacktraceState() directly, as an alternative backend to
+// its ELF symbol table reader, for the symbol name. This module additionally
+// installs itself as a symbolize.h SymbolizeCallback so that file name and line
+// number information is printed right before the demangled symbol name, the
+// same way addr2line.cc does for its backend.
+//
+// Unlike addr2line.cc, resolution happens in-process rather than through a
+// subprocess. This means the calls below are not async-signal-safe:
+// libbacktrace allocates on the heap the first time it parses a given module's
+// debug info or symbol table. This is a deliberate trade-off, consistent with
+// the one already accepted for addr2line.cc's use of fork()/exec().
+
+#ifndef NGLOG_INTERNAL_LIBBACKTRACE_H
+#define NGLOG_INTERNAL_LIBBACKTRACE_H
+
+#include <cstddef>
+
+#include "config.h"
+#include "ng-log/export.h"
+
+#ifdef HAVE_LIBBACKTRACE
+
+struct backtrace_state;
+
+namespace nglog {
+inline namespace tools {
+
+// Returns the process-wide libbacktrace state, creating it on the first
+// call. Returns nullptr if the state could not be created.
+NGLOG_NO_EXPORT
+backtrace_state* GetBacktraceState();
+
+// Formats "|filename|:|lineno| " into |out|. Returns the number of bytes
+// written, not including the terminating NUL. Returns 0 (and leaves |out|
+// untouched) if |filename| is null or empty, or if the formatted result
+// does not fit within |out_size|.
+NGLOG_NO_EXPORT
+std::size_t FormatLibbacktraceLocation(const char* filename, int lineno,
+                                       char* out, std::size_t out_size);
+
+// Installs a SymbolizeCallback (see symbolize.h) that resolves file names
+// and line numbers via libbacktrace. Returns true once the callback has
+// been installed.
+NGLOG_NO_EXPORT
+bool InstallLibbacktraceSymbolizeCallback();
+
+}  // namespace tools
+}  // namespace nglog
+
+#endif  // HAVE_LIBBACKTRACE
+
+#endif  // NGLOG_INTERNAL_LIBBACKTRACE_H

--- a/src/libbacktrace_unittest.cc
+++ b/src/libbacktrace_unittest.cc
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: 2026 The ng-log contributors
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Author: Sergiu Deitsch
+//
+// Unit tests for functions in libbacktrace.cc.
+
+#include "libbacktrace.h"
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <iostream>
+
+#include "config.h"
+#include "ng-log/flags.h"
+#include "ng-log/logging.h"
+#include "symbolize.h"
+#include "utilities.h"
+
+#ifdef NGLOG_USE_GFLAGS
+#  include <gflags/gflags.h>
+using namespace GFLAGS_NAMESPACE;
+#endif  // NGLOG_USE_GFLAGS
+
+using namespace nglog;
+
+// Tests for FormatLibbacktraceLocation.
+
+TEST(FormatLibbacktraceLocation, ResolvedLocation) {
+  char out[64];
+  const std::size_t written =
+      FormatLibbacktraceLocation("src/libbacktrace.cc", 42, out, sizeof(out));
+  EXPECT_EQ(std::strlen("src/libbacktrace.cc:42 "), written);
+  EXPECT_STREQ("src/libbacktrace.cc:42 ", out);
+}
+
+TEST(FormatLibbacktraceLocation, RejectsNullFilename) {
+  char out[64];
+  EXPECT_EQ(0U, FormatLibbacktraceLocation(nullptr, 42, out, sizeof(out)));
+}
+
+TEST(FormatLibbacktraceLocation, RejectsEmptyFilename) {
+  char out[64];
+  EXPECT_EQ(0U, FormatLibbacktraceLocation("", 42, out, sizeof(out)));
+}
+
+TEST(FormatLibbacktraceLocation, RejectsZeroSizedOutputBuffer) {
+  char out[64];
+  EXPECT_EQ(0U, FormatLibbacktraceLocation("src/libbacktrace.cc", 42, out, 0));
+}
+
+TEST(FormatLibbacktraceLocation, RejectsWhenOutputDoesNotFit) {
+  constexpr char kFilename[] = "src/libbacktrace.cc";
+  char out[8];  // Too small for "src/libbacktrace.cc:42 " + '\0'.
+  EXPECT_EQ(0U, FormatLibbacktraceLocation(kFilename, 42, out, sizeof(out)));
+}
+
+TEST(FormatLibbacktraceLocation, SucceedsWhenOutputExactlyFits) {
+  constexpr char kFilename[] = "a.cc";
+  constexpr char kExpected[] = "a.cc:1 ";
+  char out[sizeof(kExpected)];
+  const std::size_t written =
+      FormatLibbacktraceLocation(kFilename, 1, out, sizeof(out));
+  EXPECT_EQ(std::strlen(kExpected), written);
+  EXPECT_STREQ(kExpected, out);
+}
+
+TEST(FormatLibbacktraceLocation, RejectsWhenOutputIsOneByteTooSmall) {
+  constexpr char kFilename[] = "a.cc";
+  constexpr char kExpected[] = "a.cc:1 ";
+  char out[sizeof(kExpected) - 1];
+  EXPECT_EQ(0U, FormatLibbacktraceLocation(kFilename, 1, out, sizeof(out)));
+}
+
+// Tests for LibbacktraceSymbolizeCallback, exercised through Symbolize().
+
+namespace {
+
+void ATTRIBUTE_NOINLINE FunctionSymbolizedForLibbacktraceTest() {
+  volatile int a = 0;
+  a = a + 1;
+}
+
+const char* TrySymbolize(void* pc, char* out, std::size_t out_size) {
+  if (Symbolize(pc, out, out_size)) {
+    return out;
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+TEST(LibbacktraceSymbolizeCallback, ResolvesFileAndLine) {
+  FLAGS_symbolize_line_info = true;
+  EXPECT_TRUE(InstallLibbacktraceSymbolizeCallback());
+
+  char symbol[4096];
+  const char* result = TrySymbolize(
+      reinterpret_cast<void*>(&FunctionSymbolizedForLibbacktraceTest), symbol,
+      sizeof(symbol));
+  CHECK(result != nullptr);
+  InstallSymbolizeCallback(nullptr);
+
+  if (std::strstr(result, "libbacktrace_unittest.cc:") == nullptr) {
+    std::cerr << "libbacktrace has no debug info for this binary: skipping"
+              << std::endl;
+    return;
+  }
+  EXPECT_NE(nullptr,
+            std::strstr(result, "FunctionSymbolizedForLibbacktraceTest"));
+}
+
+TEST(LibbacktraceSymbolizeCallback, DisabledByFlag) {
+  FLAGS_symbolize_line_info = false;
+  EXPECT_TRUE(InstallLibbacktraceSymbolizeCallback());
+
+  char symbol[4096];
+  const char* result = TrySymbolize(
+      reinterpret_cast<void*>(&FunctionSymbolizedForLibbacktraceTest), symbol,
+      sizeof(symbol));
+  CHECK(result != nullptr);
+  EXPECT_EQ(nullptr, std::strstr(result, "libbacktrace_unittest.cc:"));
+  EXPECT_NE(nullptr,
+            std::strstr(result, "FunctionSymbolizedForLibbacktraceTest"));
+
+  FLAGS_symbolize_line_info = true;
+  InstallSymbolizeCallback(nullptr);
+}
+
+TEST(LibbacktraceSymbolizeCallback, NoDebugInfoForAddress) {
+  FLAGS_symbolize_line_info = true;
+  EXPECT_TRUE(InstallLibbacktraceSymbolizeCallback());
+
+  char symbol[4096];
+  // An address this low can never fall inside a loaded module, so
+  // backtrace_pcinfo() reports no location for it. Exercises the "not
+  // found" path in LibbacktraceSymbolizeCallback() the way a stack frame
+  // in a module without debug info would.
+  const char* result =
+      TrySymbolize(reinterpret_cast<void*>(0x1), symbol, sizeof(symbol));
+  EXPECT_EQ(nullptr, result);
+
+  InstallSymbolizeCallback(nullptr);
+}
+
+// Tests for the SymbolizeAndDemangle() branch itself, exercised through
+// Symbolize() directly.
+
+TEST(Symbolize, RejectsZeroSizedOutputBuffer) {
+  char out[1];
+  EXPECT_FALSE(Symbolize(
+      reinterpret_cast<void*>(&FunctionSymbolizedForLibbacktraceTest), out, 0));
+}
+
+TEST(Symbolize, RejectsTruncatedSymbolName) {
+  constexpr std::size_t kOutputSize = 8;
+  char out[kOutputSize];
+  FLAGS_symbolize_line_info = false;
+  InstallLibbacktraceSymbolizeCallback();
+
+  EXPECT_FALSE(
+      Symbolize(reinterpret_cast<void*>(&FunctionSymbolizedForLibbacktraceTest),
+                out, sizeof(out), SymbolizeOptions::kNoLineNumbers));
+
+  FLAGS_symbolize_line_info = true;
+  InstallSymbolizeCallback(nullptr);
+}
+
+int main(int argc, char** argv) {
+  FLAGS_logtostderr = true;
+  InitializeLogging(argv[0]);
+  testing::InitGoogleTest(&argc, argv);
+  // Independent from whatever InitializeLogging() may have installed via
+  // FLAGS_symbolize_line_info, so tests don't depend on flag defaults.
+  InstallSymbolizeCallback(nullptr);
+  return RUN_ALL_TESTS();
+}

--- a/src/ng-log/flags.h
+++ b/src/ng-log/flags.h
@@ -177,7 +177,7 @@ DECLARE_string(logmailer);
 DECLARE_bool(symbolize_stacktrace);
 
 // Resolve file names and line numbers for symbolized stack frames using
-// addr2line, if available.
+// addr2line or libbacktrace, if available.
 DECLARE_bool(symbolize_line_info);
 
 // Upper bound in milliseconds on how long to wait for addr2line to resolve

--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -124,7 +124,109 @@ void InstallSymbolizeOpenObjectFileCallback(
 }  // namespace tools
 }  // namespace nglog
 
-#  if defined(HAVE_LINK_H)
+#  if defined(HAVE_LIBBACKTRACE)
+
+#    include <backtrace.h>
+
+#    include <cstdint>
+
+#    include "libbacktrace.h"
+
+namespace nglog {
+inline namespace tools {
+
+namespace {
+
+struct SymInfoContext {
+  char* out;
+  size_t out_size;
+  bool found;
+};
+
+void SymInfoCallback(void* data, uintptr_t /*pc*/, const char* symname,
+                     uintptr_t /*symval*/, uintptr_t /*symsize*/) {
+  auto* ctx = static_cast<SymInfoContext*>(data);
+  if (symname == nullptr || ctx->out_size == 0) {
+    return;
+  }
+  const size_t symbol_length = std::strlen(symname);
+  if (symbol_length >= ctx->out_size) {
+    return;
+  }
+  std::memcpy(ctx->out, symname, symbol_length + 1);
+  ctx->found = true;
+}
+
+// Only reached via libbacktrace's own error path (e.g. a module with no
+// symbol table at all), not the ordinary "nothing found" one, so nothing
+// here exercises it: the test binaries always carry a symbol table.
+// LCOV_EXCL_START
+void ErrorCallback(void* /*data*/, const char* /*msg*/, int /*errnum*/) {}
+// LCOV_EXCL_STOP
+
+}  // namespace
+
+// Uses libbacktrace's symbol table reader (backtrace_syminfo()) in place of
+// the hand-rolled ELF reader below, and libbacktrace's DWARF reader
+// (backtrace_pcinfo(), via the callback InstallLibbacktraceSymbolizeCallback()
+// installs) in place of addr2line for file name and line number
+// information. Unlike the branches below, module discovery for a given
+// "pc" is handled entirely inside libbacktrace, so neither
+// OpenObjectFileContainingPcAndGetStartAddress() nor
+// g_symbolize_open_object_file_callback is consulted here.
+static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(void* pc, char* out,
+                                                    size_t out_size,
+                                                    SymbolizeOptions options,
+                                                    SymbolizedFrame* frame) {
+  if (out_size < 1) {
+    return false;
+  }
+  out[0] = '\0';
+
+  if (g_symbolize_callback && (options & SymbolizeOptions::kNoLineNumbers) !=
+                                  SymbolizeOptions::kNoLineNumbers) {
+    // Run the file/line callback first, exactly as the ELF reader below
+    // does, so its output ends up as a prefix before the symbol name. "fd"
+    // and "relocation" are unused by LibbacktraceSymbolizeCallback():
+    // libbacktrace resolves the containing module and applies the load
+    // bias internally, from the raw runtime "pc".
+    int num_bytes_written = g_symbolize_callback(-1, pc, out, out_size, 0);
+    if (num_bytes_written > 0) {
+      if (frame != nullptr) {
+        // The callback writes "<file>:<line> " (see
+        // FormatLibbacktraceLocation()). Trim the trailing space so the
+        // span covers exactly "<file>:<line>".
+        const auto written = static_cast<size_t>(num_bytes_written);
+        frame->file_line_offset = 0;
+        frame->file_line_length = written > 1 ? written - 1 : 0;
+      }
+      out += static_cast<size_t>(num_bytes_written);
+      out_size -= static_cast<size_t>(num_bytes_written);
+    }
+  }
+
+  backtrace_state* const state = GetBacktraceState();
+  if (state == nullptr) {
+    return false;
+  }
+
+  SymInfoContext ctx{out, out_size, false};
+  backtrace_syminfo(state, reinterpret_cast<uintptr_t>(pc), &SymInfoCallback,
+                    &ErrorCallback, &ctx);
+
+  if (!ctx.found) {
+    return false;
+  }
+
+  // Symbolization succeeded.  Now we try to demangle the symbol.
+  DemangleInplace(out, out_size);
+  return true;
+}
+
+}  // namespace tools
+}  // namespace nglog
+
+#  elif defined(HAVE_LINK_H)
 
 #    if defined(HAVE_DLFCN_H)
 #      include <dlfcn.h>
@@ -752,9 +854,10 @@ static void SafeAppendHexNumber(uint64_t value, char* dest, size_t dest_size) {
 // and "out" is used as its output.
 // To keep stack consumption low, we would like this function to not
 // get inlined.
-static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(
-    void* pc, char* out, size_t out_size, SymbolizeOptions options,
-    SymbolizedFrame* frame) {
+static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(void* pc, char* out,
+                                                    size_t out_size,
+                                                    SymbolizeOptions options,
+                                                    SymbolizedFrame* frame) {
   auto pc0 = reinterpret_cast<uintptr_t>(pc);
   uint64_t start_address = 0;
   uint64_t base_address = 0;

--- a/src/symbolize_unittest.cc
+++ b/src/symbolize_unittest.cc
@@ -446,8 +446,17 @@ TEST(Symbolize, SymbolizeWithDemangling) {
   }
 #    endif  // defined(HAVE_ADDR2LINE)
 
-#    if defined(HAVE_DBGHELP) && !defined(HAVE_ADDR2LINE) && !defined(NDEBUG)
+  // Which demangled form to expect depends on the compiler's name-mangling
+  // ABI, not merely on HAVE_DBGHELP being available: MinGW and Clang on
+  // Windows mangle (and demangle) with the Itanium ABI, like on Linux or
+  // macOS, even though DbgHelp itself is present. Only MSVC produces the
+  // decorated form below.
+#    if defined(_MSC_VER)
+#      if !defined(NDEBUG)
   EXPECT_STREQ("public: static void __cdecl Foo::func(int)", ret);
+#      endif
+#    elif !defined(NDEBUG)
+  EXPECT_STREQ("Foo::func(int)", ret);
 #    endif
 }
 
@@ -499,7 +508,17 @@ int main(int argc, char** argv) {
   TestWithReturnAddress();
   return RUN_ALL_TESTS();
 #  elif defined(NGLOG_OS_WINDOWS) || defined(NGLOG_OS_CYGWIN)
+  // Run first, while whatever callback InitializeLogging() may have
+  // installed (e.g. for libbacktrace) is still active: it passes
+  // kNoLineNumbers itself, so it also exercises that a caller-requested
+  // "no line numbers" is honored even with a callback installed.
   TestWithReturnAddress();
+
+  // The tests below want bare, undecorated names, so make sure they are
+  // not affected by whatever callback InitializeLogging() may have
+  // installed.
+  InstallSymbolizeCallback(nullptr);
+
   return RUN_ALL_TESTS();
 #  else   // NGLOG_OS_WINDOWS
   printf("PASS (no symbolize_unittest support)\n");

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -43,6 +43,7 @@
 #include "addr2line.h"
 #include "config.h"
 #include "initializer.h"
+#include "libbacktrace.h"
 #include "ng-log/flags.h"
 #include "ng-log/logging.h"
 #include "stacktrace.h"
@@ -304,7 +305,11 @@ void InitializeLoggingUtilities(const char* argv0) {
 #ifdef HAVE_STACKTRACE
   InstallFailureFunction(&DumpStackTraceAndExit);
 #endif
-#ifdef HAVE_ADDR2LINE
+#ifdef HAVE_LIBBACKTRACE
+  if (FLAGS_symbolize_line_info) {
+    InstallLibbacktraceSymbolizeCallback();
+  }
+#elif defined(HAVE_ADDR2LINE)
   if (FLAGS_symbolize_line_info) {
     InstallAddr2LineSymbolizeCallback();
   }


### PR DESCRIPTION
Stack traces are currently symbolized either by a hand-rolled ELF symbol table reader or, for file names and line numbers, by shelling out to `addr2line` per frame. libbacktrace resolves both the symbol name and the file and line number in-process, straight from the DWARF and symbol table, without spawning a subprocess for every address.

Add it as a new optional backend. When available it becomes the symbol name resolver used by `Symbolize()` and, through the existing SymbolizeCallback hook, the file and line resolver, taking over from `addr2line` so a crash report no longer depends on spawning a process per frame.
