### PR TITLE
perf: avoid constructing disabled log messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1151,7 +1151,12 @@ if (BUILD_TESTING AND GTest_FOUND)
   add_executable (striplog10_unittest
     src/striplog_unittest.cc
   )
-  target_compile_definitions (striplog10_unittest PRIVATE NGLOG_STRIP_LOG=10)
+  target_compile_definitions (striplog10_unittest PRIVATE
+    ERROR=0
+    NDEBUG
+    NGLOG_NO_ABBREVIATED_SEVERITIES
+    NGLOG_STRIP_LOG=10
+  )
   target_link_libraries (striplog10_unittest PRIVATE ng-log_test)
 
   add_test (NAME striplog10 COMMAND striplog10_unittest)

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -13,6 +13,8 @@
 - Prevent concurrent log writers from blocking during memory-drop maintenance
 - Make log cleanup work with non-ASCII Windows directories
 - Omit the default header format when a custom prefix formatter is installed
+- Improve suppressed logging performance by avoiding message construction and
+  reduce overhead when formatting default prefixes
 - Include the current thread name in failure signal reports when available
 
 !!! warning "Compatibility"

--- a/src/color_attributes_unittest.cc
+++ b/src/color_attributes_unittest.cc
@@ -213,6 +213,38 @@ TEST(ColorAttributes, ErrnoThemeUsesDistinctRoles) {
 }
 
 #if !defined(NGLOG_OS_WINDOWS)
+TEST(ColorAttributes, DefaultPrefixRetainsPerFieldColors) {
+  ASSERT_EQ(setenv("CLICOLOR_FORCE", "1", 1), 0);
+  ASSERT_EQ(setenv("TERM", "xterm", 1), 0);
+  unsetenv("NO_COLOR");
+
+  const bool old_logtostderr = FLAGS_logtostderr;
+  const bool old_colorlogtostderr = FLAGS_colorlogtostderr;
+  const bool old_log_prefix = FLAGS_log_prefix;
+  const int old_minloglevel = FLAGS_minloglevel;
+  const bool old_symbolize_hyperlinks = FLAGS_symbolize_hyperlinks;
+  FLAGS_logtostderr = true;
+  FLAGS_colorlogtostderr = true;
+  FLAGS_log_prefix = true;
+  FLAGS_minloglevel = NGLOG_INFO;
+  FLAGS_symbolize_hyperlinks = false;
+
+  CaptureTestStderr();
+  LOG(INFO) << "colored default prefix";
+  const std::string output = GetCapturedTestStderr();
+
+  FLAGS_logtostderr = old_logtostderr;
+  FLAGS_colorlogtostderr = old_colorlogtostderr;
+  FLAGS_log_prefix = old_log_prefix;
+  FLAGS_minloglevel = old_minloglevel;
+  FLAGS_symbolize_hyperlinks = old_symbolize_hyperlinks;
+
+  EXPECT_THAT(output, HasSubstr("\033[34m"));
+  EXPECT_THAT(output, HasSubstr("\033[35m"));
+  EXPECT_THAT(output, HasSubstr("\033[36m"));
+  EXPECT_THAT(output, HasSubstr("\033[90m]"));
+}
+
 TEST(ColorAttributes, RendersStyledSpansAndHyperlinksOnAnsiOutput) {
   ASSERT_EQ(setenv("CLICOLOR_FORCE", "1", 1), 0);
   ASSERT_EQ(setenv("TERM", "xterm", 1), 0);

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -33,6 +33,7 @@
 #include "ng-log/logging.h"
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <chrono>
 #include <condition_variable>
@@ -324,6 +325,85 @@ namespace {
 
 constexpr std::intmax_t kSecondsInDay = 60 * 60 * 24;
 constexpr std::intmax_t kSecondsInWeek = kSecondsInDay * 7;
+constexpr std::size_t kPrefixNumberBufferSize = 32;
+constexpr std::size_t kPrefixYearWidth = 4;
+constexpr std::size_t kPrefixMonthWidth = 2;
+constexpr std::size_t kPrefixDayWidth = 2;
+constexpr std::size_t kPrefixHourWidth = 2;
+constexpr std::size_t kPrefixMinuteWidth = 2;
+constexpr std::size_t kPrefixSecondWidth = 2;
+constexpr std::size_t kPrefixMicrosecondWidth = 6;
+constexpr std::size_t kPrefixThreadIdWidth = 5;
+constexpr unsigned int kPrefixDecimalBase = 10;
+
+void AppendPrefixText(LogMessage::LogStream& stream, const char* text) {
+  stream.append(text, std::strlen(text));
+}
+
+template <typename Integer>
+void AppendPrefixNumber(LogMessage::LogStream& stream, Integer value,
+                        std::size_t width = 0) {
+  std::array<char, kPrefixNumberBufferSize> number;
+  using UnsignedInteger = typename std::make_unsigned<Integer>::type;
+  const bool negative = value < 0;
+  UnsignedInteger magnitude =
+      negative ? static_cast<UnsignedInteger>(-(value + 1)) + 1
+               : static_cast<UnsignedInteger>(value);
+  char* end = number.data() + number.size();
+  char* begin = end;
+  do {
+    const unsigned int digit = magnitude % kPrefixDecimalBase;
+    *--begin = static_cast<char>('0' + digit);
+    magnitude /= kPrefixDecimalBase;
+  } while (magnitude != 0);
+  if (negative) *--begin = '-';
+
+  const std::size_t digits = static_cast<std::size_t>(end - begin);
+  if (digits < width) {
+    // number has ample unused space ahead of begin (kPrefixNumberBufferSize
+    // comfortably exceeds any width in use here), so the zero padding can be
+    // written directly in front of the digits already extracted above,
+    // instead of copying them into a second buffer.
+    const std::size_t zeroes = width - digits;
+    begin -= zeroes;
+    std::fill_n(begin, zeroes, '0');
+  }
+  stream.append(begin, std::max(digits, width));
+}
+
+void AppendDefaultPrefix(internal::LogMessageData& data, LogSeverity severity,
+                         const LogMessageTime& time) {
+  LogMessage::LogStream& stream = data.stream_;
+  stream.append(LogSeverityNames[severity], 1);
+  data.prefix_severity_len_ = stream.pcount();
+  if (FLAGS_log_year_in_prefix) {
+    AppendPrefixNumber(stream, 1900 + time.year(), kPrefixYearWidth);
+  }
+  AppendPrefixNumber(stream, 1 + time.month(), kPrefixMonthWidth);
+  AppendPrefixNumber(stream, time.day(), kPrefixDayWidth);
+  AppendPrefixText(stream, " ");
+  AppendPrefixNumber(stream, time.hour(), kPrefixHourWidth);
+  AppendPrefixText(stream, ":");
+  AppendPrefixNumber(stream, time.min(), kPrefixMinuteWidth);
+  AppendPrefixText(stream, ":");
+  AppendPrefixNumber(stream, time.sec(), kPrefixSecondWidth);
+  AppendPrefixText(stream, ".");
+  AppendPrefixNumber(stream, time.usec(), kPrefixMicrosecondWidth);
+  data.prefix_timestamp_len_ = stream.pcount() - data.prefix_severity_len_;
+  AppendPrefixText(stream, " ");
+  stream << std::setw(kPrefixThreadIdWidth) << data.thread_id_;
+  data.prefix_threadid_len_ = stream.pcount() - data.prefix_severity_len_ -
+                              data.prefix_timestamp_len_ - 1;
+  AppendPrefixText(stream, " ");
+  AppendPrefixText(stream, data.basename_);
+  AppendPrefixText(stream, ":");
+  AppendPrefixNumber(stream, data.line_);
+  data.prefix_fileline_len_ = stream.pcount() - data.prefix_severity_len_ -
+                              data.prefix_timestamp_len_ - 1 -
+                              data.prefix_threadid_len_ - 1;
+  AppendPrefixText(stream, "] ");
+  data.has_default_prefix_ = true;
+}
 
 // Optional user-configured callback to print custom prefixes.
 class PrefixFormatter {
@@ -2028,42 +2108,16 @@ void LogMessage::Init(const char* file, int line, LogSeverity severity,
   //    (log level, GMT year, month, date, time, thread_id, file basename, line)
   // We exclude the thread_id for the default thread.
   if (FLAGS_log_prefix && (line != kNoLogPrefix)) {
-    std::ios saved_fmt(nullptr);
-    saved_fmt.copyfmt(stream());
-    stream().fill('0');
     if (g_prefix_formatter == nullptr) {
-      stream() << LogSeverityNames[severity][0];
-      // Split into several statements, rather than one long chain of
-      // "<<", to snapshot pcount() between fields below: doing so lets
-      // ColoredWriteToStderrOrStdout() colorize the severity character,
-      // timestamp, thread id, and file:line fields of the prefix
-      // independently, without having to reparse the composed text.
-      data_->prefix_severity_len_ = data_->stream_.pcount();
-      if (FLAGS_log_year_in_prefix) {
-        stream() << setw(4) << 1900 + time_.year();
-      }
-      stream() << setw(2) << 1 + time_.month() << setw(2) << time_.day() << ' '
-               << setw(2) << time_.hour() << ':' << setw(2) << time_.min()
-               << ':' << setw(2) << time_.sec() << "." << setw(6)
-               << time_.usec();
-      data_->prefix_timestamp_len_ =
-          data_->stream_.pcount() - data_->prefix_severity_len_;
-      stream() << ' ' << setfill(' ') << setw(5) << data_->thread_id_
-               << setfill('0');
-      data_->prefix_threadid_len_ = data_->stream_.pcount() -
-                                    data_->prefix_severity_len_ -
-                                    data_->prefix_timestamp_len_ - 1;
-      stream() << ' ' << data_->basename_ << ':' << data_->line_;
-      data_->prefix_fileline_len_ =
-          data_->stream_.pcount() - data_->prefix_severity_len_ -
-          data_->prefix_timestamp_len_ - 1 - data_->prefix_threadid_len_ - 1;
-      stream() << "] ";
-      data_->has_default_prefix_ = true;
+      AppendDefaultPrefix(*data_, severity, time_);
     } else {
+      std::ios saved_fmt(nullptr);
+      saved_fmt.copyfmt(stream());
+      stream().fill('0');
       (*g_prefix_formatter)(stream(), *this);
       stream() << " ";
+      stream().copyfmt(saved_fmt);
     }
-    stream().copyfmt(saved_fmt);
   }
   data_->num_prefix_chars_ = data_->stream_.pcount();
 
@@ -2342,7 +2396,10 @@ logging_fail_func_t InstallFailureFunction(logging_fail_func_t fail_func) {
   return std::exchange(g_logging_fail_func, fail_func);
 }
 
-void LogMessage::Fail() { g_logging_fail_func(); }
+void LogMessage::Fail() {
+  g_logging_fail_func();
+  std::abort();
+}
 
 // L >= log_mutex (callers must hold the log_mutex).
 void LogMessage::SendToSink() EXCLUSIVE_LOCKS_REQUIRED(log_mutex) {

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -133,6 +133,10 @@ void PrefixAttacher(std::ostream& s, const LogMessage& m, void* data) {
     << m.basename() << ':' << m.line() << "]";
 }
 
+[[noreturn]] void ThrowFatalLogFailure() {
+  throw std::logic_error{"fatal log"};
+}
+
 // Captured pre-init, re-emitted by LoggingGoldenFile.Stderr.
 std::string early_stderr;
 
@@ -1582,6 +1586,58 @@ TEST(LogAtLevel, Basic) {
   severity = NGLOG_INFO;
   // We can use the macro version as a C++ stream.
   LOG_AT_LEVEL(severity) << "macro" << ' ' << "version";
+}
+
+TEST(Logging, DisabledConditionalLogDoesNotEvaluateArguments) {
+  const int saved_min_log_level = FLAGS_minloglevel;
+  FLAGS_minloglevel = NGLOG_ERROR;
+  testing::MockFunction<int()> disabled_log_argument;
+  EXPECT_CALL(disabled_log_argument, Call()).Times(0);
+
+  LOG_IF(INFO, true) << disabled_log_argument.AsStdFunction()();
+
+  FLAGS_minloglevel = saved_min_log_level;
+}
+
+TEST(Logging, FatalIgnoresMinimumLogLevel) {
+  const int saved_min_log_level = FLAGS_minloglevel;
+  FLAGS_minloglevel = NGLOG_FATAL + 1;
+  auto const fail_func = InstallFailureFunction(&ThrowFatalLogFailure);
+  auto restore = [fail_func, saved_min_log_level] {
+    InstallFailureFunction(fail_func);
+    FLAGS_minloglevel = saved_min_log_level;
+  };
+  ScopedExit<decltype(restore)> restore_state{restore};
+
+  EXPECT_THROW({ LOG(FATAL) << "fatal log"; }, std::logic_error);
+  const auto fatal_check = [] { CHECK(false) << "fatal check"; };
+  EXPECT_THROW(fatal_check(), std::logic_error);
+}
+
+TEST(Logging, DefaultPrefixFormatting) {
+  const bool saved_log_to_stderr = FLAGS_logtostderr;
+  const int saved_stderr_threshold = FLAGS_stderrthreshold;
+  const bool saved_log_prefix = FLAGS_log_prefix;
+  const int saved_min_log_level = FLAGS_minloglevel;
+
+  FLAGS_logtostderr = true;
+  FLAGS_stderrthreshold = NGLOG_INFO;
+  FLAGS_log_prefix = true;
+  FLAGS_minloglevel = NGLOG_INFO;
+  InstallPrefixFormatter(nullptr);
+
+  CaptureTestStderr();
+  LOG(INFO) << "default prefix formatting";
+  const std::string output = GetCapturedTestStderr();
+
+  InstallPrefixFormatter(&PrefixAttacher, &g_prefix_attacher_data);
+  FLAGS_logtostderr = saved_log_to_stderr;
+  FLAGS_stderrthreshold = saved_stderr_threshold;
+  FLAGS_log_prefix = saved_log_prefix;
+  FLAGS_minloglevel = saved_min_log_level;
+
+  EXPECT_THAT(output, HasSubstr("] default prefix formatting\n"));
+  EXPECT_THAT(output, testing::Not(HasSubstr("good data")));
 }
 
 TEST(TestExitOnDFatal, ToBeOrNotToBe) {

--- a/src/ng-log/log_severity.h
+++ b/src/ng-log/log_severity.h
@@ -63,7 +63,7 @@ constexpr int kFatalSeverity = 3;
 // [0, NUM_SEVERITIES-1].  Be careful to preserve this assumption if
 // you ever need to change their values or add a new severity.
 
-enum LogSeverity {
+enum LogSeverity : int {
 #ifndef NGLOG_NO_ABBREVIATED_SEVERITIES
 #  ifdef ERROR
 #  error "ERROR macro is defined. Define NGLOG_NO_ABBREVIATED_SEVERITIES before including logging.h. See https://ng-log.github.io/ng-log/stable/windows/ for details."

--- a/src/ng-log/logging.h
+++ b/src/ng-log/logging.h
@@ -442,7 +442,28 @@ struct NGLOG_EXPORT LogMessageTime {
 // impossible to stream something like a string directly to an unnamed
 // ostream. We employ a neat hack by calling the stream() member
 // function of LogMessage which seems to avoid the problem.
-#define LOG(severity) NGLOG_COMPACT_LOG_##severity.stream()
+#define NGLOG_LOG_SEVERITY_INFO NGLOG_INFO
+#define NGLOG_LOG_SEVERITY_WARNING NGLOG_WARNING
+#define NGLOG_LOG_SEVERITY_ERROR NGLOG_ERROR
+#define NGLOG_LOG_SEVERITY_FATAL NGLOG_FATAL
+#define NGLOG_LOG_SEVERITY_DFATAL DFATAL_LEVEL
+#if defined(NGLOG_NO_ABBREVIATED_SEVERITIES)
+#  define NGLOG_LOG_SEVERITY_0 NGLOG_ERROR
+#endif
+#define NGLOG_LOG_SEVERITY(severity) NGLOG_LOG_SEVERITY_##severity
+#define NGLOG_LOG_SEVERITY_ENABLED(severity)      \
+  (NGLOG_LOG_SEVERITY(severity) == NGLOG_FATAL || \
+   FLAGS_minloglevel <= NGLOG_LOG_SEVERITY(severity))
+
+#define NGLOG_LOG_IF(severity, condition) \
+  static_cast<void>(0),                   \
+      !(condition) ? (void)0              \
+                   : nglog::internal::LogMessageVoidify() & LOG(severity)
+
+#define LOG(severity)                          \
+  (NGLOG_LOG_SEVERITY_ENABLED(severity)        \
+       ? NGLOG_COMPACT_LOG_##severity.stream() \
+       : nglog::NullStream().stream())
 #define SYSLOG(severity) SYSLOG_##severity(0).stream()
 
 namespace nglog {
@@ -457,11 +478,7 @@ NGLOG_EXPORT bool IsLoggingInitialized();
 // Shutdown logging.
 NGLOG_EXPORT void ShutdownLogging();
 
-#if defined(__GNUC__)
-typedef void (*logging_fail_func_t)() __attribute__((noreturn));
-#else
 typedef void (*logging_fail_func_t)();
-#endif
 
 class LogMessage;
 
@@ -525,9 +542,7 @@ class LogSink;  // defined below
       .stream()
 
 #define LOG_IF(severity, condition) \
-  static_cast<void>(0),             \
-      !(condition) ? (void)0        \
-                   : nglog::internal::LogMessageVoidify() & LOG(severity)
+  NGLOG_LOG_IF(severity, (condition) && NGLOG_LOG_SEVERITY_ENABLED(severity))
 #define SYSLOG_IF(severity, condition) \
   static_cast<void>(0),                \
       !(condition) ? (void)0           \
@@ -1024,42 +1039,24 @@ constexpr LogSeverity NGLOG_0 = NGLOG_ERROR;
 
 #else  // !DCHECK_IS_ON()
 
-#  define DLOG(severity)  \
-    static_cast<void>(0), \
-        true ? (void)0 : nglog::internal::LogMessageVoidify() & LOG(severity)
+#  define DLOG(severity) NGLOG_LOG_IF(severity, false)
 
-#  define DVLOG(verboselevel)               \
-    static_cast<void>(0),                   \
-        (true || !VLOG_IS_ON(verboselevel)) \
-            ? (void)0                       \
-            : nglog::internal::LogMessageVoidify() & LOG(INFO)
+#  define DVLOG(verboselevel) \
+    NGLOG_LOG_IF(INFO, false && VLOG_IS_ON(verboselevel))
 
 #  define DLOG_IF(severity, condition) \
-    static_cast<void>(0),              \
-        (true || !(condition))         \
-            ? (void)0                  \
-            : nglog::internal::LogMessageVoidify() & LOG(severity)
+    NGLOG_LOG_IF(severity, false && (condition))
 
-#  define DLOG_EVERY_N(severity, n) \
-    static_cast<void>(0),           \
-        true ? (void)0 : nglog::internal::LogMessageVoidify() & LOG(severity)
+#  define DLOG_EVERY_N(severity, n) NGLOG_LOG_IF(severity, false)
 
 #  define DLOG_IF_EVERY_N(severity, condition, n) \
-    static_cast<void>(0),                         \
-        (true || !(condition))                    \
-            ? (void)0                             \
-            : nglog::internal::LogMessageVoidify() & LOG(severity)
+    NGLOG_LOG_IF(severity, false && (condition))
 
-#  define DLOG_FIRST_N(severity, n) \
-    static_cast<void>(0),           \
-        true ? (void)0 : nglog::internal::LogMessageVoidify() & LOG(severity)
+#  define DLOG_FIRST_N(severity, n) NGLOG_LOG_IF(severity, false)
 
-#  define DLOG_EVERY_T(severity, T) \
-    static_cast<void>(0),           \
-        true ? (void)0 : nglog::internal::LogMessageVoidify() & LOG(severity)
+#  define DLOG_EVERY_T(severity, T) NGLOG_LOG_IF(severity, false)
 
-#  define DLOG_ASSERT(condition) \
-    static_cast<void>(0), true ? (void)0 : (LOG_ASSERT(condition))
+#  define DLOG_ASSERT(condition) NGLOG_LOG_IF(FATAL, false && (condition))
 
 // MSVC warning C4127: conditional expression is constant
 #  define DCHECK(condition)               \
@@ -1134,6 +1131,14 @@ class NGLOG_EXPORT LogStreamBuf : public std::streambuf {
  public:
   // REQUIREMENTS: "len" must be >= 2 to account for the '\n' and '\0'.
   LogStreamBuf(char* buf, int len) { setp(buf, buf + len - 2); }
+
+  void append(const char* data, std::size_t length) {
+    std::size_t count = length;
+    const std::size_t available = static_cast<std::size_t>(epptr() - pptr());
+    if (count > available) count = available;
+    std::memcpy(pptr(), data, count);
+    pbump(static_cast<int>(count));
+  }
 
   // This effectively ignores overflow.
   int_type overflow(int_type ch) { return ch; }
@@ -1223,6 +1228,9 @@ class NGLOG_EXPORT LogMessage {
     size_t pcount() const { return streambuf_.pcount(); }
     char* pbase() const { return streambuf_.pbase(); }
     char* str() const { return pbase(); }
+    void append(const char* data, std::size_t length) {
+      streambuf_.append(data, length);
+    }
 
     LogStream(const LogStream&) = delete;
     LogStream& operator=(const LogStream&) = delete;
@@ -1656,7 +1664,12 @@ class NGLOG_EXPORT NullStream : public LogMessage::LogStream {
 // something like (flag ? LOG(INFO) : LOG(ERROR)) << message; when
 // SKIP_LOG=WARNING. In those cases, NullStream will be implicitly
 // converted to LogStream and the message will be computed and then
-// quietly discarded.
+// quietly discarded. The same holds for a severity disabled purely at
+// runtime via FLAGS_minloglevel: LOG(severity) still resolves to a
+// single, statically typed conditional expression, so its result type
+// is fixed at compile time and the message is still computed (only its
+// output is discarded) whenever LOG(severity) is used as anything other
+// than the immediate left-hand side of its own "<<" chain.
 template <class T>
 inline NullStream& operator<<(NullStream& str, const T&) {
   return str;

--- a/src/striplog_unittest.cc
+++ b/src/striplog_unittest.cc
@@ -83,5 +83,10 @@ int main(int, char* argv[]) {
   LOG(ERROR) << "TESTMESSAGE ERROR";
   bool flag = true;
   (flag ? LOG(INFO) : LOG(ERROR)) << "TESTMESSAGE COND";
+#if !DCHECK_IS_ON()
+  DLOG(INFO) << "no debug output";
+  DLOG_IF(WARNING, true) << "no conditional debug output";
+  DVLOG(1) << "no verbose debug output";
+#endif
   LOG(FATAL) << "TESTMESSAGE FATAL";
 }


### PR DESCRIPTION
Evaluate severity guards before creating stream state so disabled logging does not format arguments. Stream default prefixes directly to reduce formatting overhead while preserving output.