### PR TITLE
perf: reduce logging lock contention

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ include (GNUInstallDirs)
 
 option (BUILD_SHARED_LIBS "Build shared libraries" ON)
 option (BUILD_EXAMPLES "Build examples" ON)
+option (WITH_LOCK_METRICS
+  "Enable internal lock contention metrics" OFF)
 option (PRINT_UNSYMBOLIZED_STACK_TRACES
   "Print file offsets in traces instead of symbolizing" OFF)
 option (WITH_GFLAGS "Use gflags" ON)
@@ -484,6 +486,7 @@ set (NGLOG_SRCS
   src/base/commandlineflags.h
   src/internal/color_format.cc
   src/internal/hyperlink.cc
+  src/internal/lock_metrics.cc
   src/internal/source_location.cc
   src/internal/style_recorder.cc
   src/internal/styled_output.cc
@@ -508,6 +511,7 @@ set (NGLOG_SRCS
   src/ng-log/internal/text_attributes.h
   src/ng-log/internal/text_style.h
   src/internal/source_location.h
+  src/internal/lock_metrics.h
   src/internal/style_recorder.h
   src/internal/styled_output.h
   src/internal/terminal_capabilities.h
@@ -536,6 +540,10 @@ add_library (ng-log_internal OBJECT
 )
 target_compile_features (ng-log_internal PUBLIC $<TARGET_PROPERTY:ng-log,COMPILE_FEATURES>)
 set_target_properties (ng-log_internal PROPERTIES DEFINE_SYMBOL ng_log_EXPORTS)
+
+if (WITH_LOCK_METRICS)
+  target_compile_definitions (ng-log_internal PRIVATE NGLOG_ENABLE_LOCK_METRICS)
+endif (WITH_LOCK_METRICS)
 
 # Some generators (such as Xcode) do not generate any output if the target does
 # not reference at least one source file.
@@ -710,6 +718,9 @@ if (BUILD_TESTING AND GTest_FOUND)
     $<TARGET_PROPERTY:ng-log,LINK_LIBRARIES> GTest::gtest GTest::gmock)
   target_compile_definitions (ng-log_test INTERFACE NGLOG_STATIC_DEFINE
     $<TARGET_PROPERTY:ng-log,COMPILE_DEFINITIONS>)
+  if (WITH_LOCK_METRICS)
+    target_compile_definitions (ng-log_test INTERFACE NGLOG_ENABLE_LOCK_METRICS)
+  endif (WITH_LOCK_METRICS)
   target_compile_features (ng-log_test INTERFACE
     $<TARGET_PROPERTY:ng-log,COMPILE_FEATURES>)
   target_include_directories (ng-log_test INTERFACE $<TARGET_PROPERTY:ng-log,INCLUDE_DIRECTORIES>)
@@ -736,6 +747,8 @@ if (BUILD_TESTING AND GTest_FOUND)
     TEST_PREFIX logtostdout.
     DISCOVERY_TIMEOUT 30
     DISCOVERY_MODE PRE_TEST
+    PROPERTIES
+      RESOURCE_LOCK captured_stream
   )
 
   add_executable (stl_logging_unittest
@@ -927,6 +940,8 @@ if (BUILD_TESTING AND GTest_FOUND)
   gtest_discover_tests (color_attributes_unittest
     TEST_PREFIX color_attributes.
     DISCOVERY_TIMEOUT 30
+    PROPERTIES
+      RESOURCE_LOCK captured_stream
   )
 
   if (TARGET signalhandler_unittest)
@@ -1374,6 +1389,9 @@ if (benchmark_FOUND)
   )
 
   target_link_libraries (logging_benchmark PRIVATE ng-log benchmark::benchmark)
+  if (WITH_LOCK_METRICS)
+    target_compile_definitions (logging_benchmark PRIVATE NGLOG_ENABLE_LOCK_METRICS)
+  endif (WITH_LOCK_METRICS)
 endif (benchmark_FOUND)
 
 if (BUILD_EXAMPLES)

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -15,6 +15,7 @@
 - Omit the default header format when a custom prefix formatter is installed
 - Improve suppressed logging performance by avoiding message construction and
   reduce overhead when formatting default prefixes
+- Improve logging throughput for applications that log from multiple threads
 - Include the current thread name in failure signal reports when available
 
 !!! warning "Compatibility"

--- a/src/internal/lock_metrics.cc
+++ b/src/internal/lock_metrics.cc
@@ -1,0 +1,218 @@
+// SPDX-FileCopyrightText: 2026 The ng-log contributors
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Author: Sergiu Deitsch
+
+#include "internal/lock_metrics.h"
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <type_traits>
+
+namespace nglog {
+namespace internal {
+namespace {
+
+constexpr std::size_t kLockKindCount = static_cast<std::size_t>(
+    static_cast<std::underlying_type_t<LockKind>>(LockKind::kCount));
+using LockKindIndex = std::underlying_type_t<LockKind>;
+
+struct MetricsStorage {
+  std::array<std::atomic<std::uint64_t>, kLockKindCount> acquisitions{};
+  std::array<std::atomic<std::uint64_t>, kLockKindCount>
+      contended_acquisitions{};
+  std::array<std::atomic<std::uint64_t>, kLockKindCount> wait_nanoseconds{};
+  std::array<std::atomic<std::uint64_t>, kLockKindCount> hold_nanoseconds{};
+};
+
+#ifdef NGLOG_ENABLE_LOCK_METRICS
+MetricsStorage metrics;
+#endif
+
+struct ThreadLockState {
+  std::array<std::chrono::steady_clock::time_point, kLockKindCount>
+      acquired_at{};
+  std::array<bool, kLockKindCount> owns{};
+};
+
+thread_local ThreadLockState thread_lock_state;
+
+void RecordAcquisition(LockKind kind,
+                       std::chrono::steady_clock::duration wait) {
+#ifdef NGLOG_ENABLE_LOCK_METRICS
+  const LockKindIndex index = static_cast<LockKindIndex>(kind);
+  metrics.acquisitions[index].fetch_add(1, std::memory_order_relaxed);
+  if (wait > std::chrono::steady_clock::duration::zero()) {
+    metrics.contended_acquisitions[index].fetch_add(1,
+                                                    std::memory_order_relaxed);
+  }
+  metrics.wait_nanoseconds[index].fetch_add(
+      static_cast<std::uint64_t>(
+          std::chrono::duration_cast<std::chrono::nanoseconds>(wait).count()),
+      std::memory_order_relaxed);
+#else
+  (void)kind;
+  (void)wait;
+#endif
+}
+
+}  // namespace
+
+void ResetLockMetrics() {
+#ifdef NGLOG_ENABLE_LOCK_METRICS
+  for (std::size_t i = 0; i < kLockKindCount; ++i) {
+    metrics.acquisitions[i].store(0, std::memory_order_relaxed);
+    metrics.contended_acquisitions[i].store(0, std::memory_order_relaxed);
+    metrics.wait_nanoseconds[i].store(0, std::memory_order_relaxed);
+    metrics.hold_nanoseconds[i].store(0, std::memory_order_relaxed);
+  }
+#endif
+}
+
+LockMetrics GetLockMetrics(LockKind kind) {
+#ifdef NGLOG_ENABLE_LOCK_METRICS
+  const LockKindIndex index = static_cast<LockKindIndex>(kind);
+  return {
+      metrics.acquisitions[index].load(std::memory_order_relaxed),
+      metrics.contended_acquisitions[index].load(std::memory_order_relaxed),
+      metrics.wait_nanoseconds[index].load(std::memory_order_relaxed),
+      metrics.hold_nanoseconds[index].load(std::memory_order_relaxed),
+  };
+#else
+  (void)kind;
+  return {0, 0, 0, 0};
+#endif
+}
+
+template <LockKind Kind>
+void InstrumentedMutex<Kind>::lock() {
+  const auto start = std::chrono::steady_clock::now();
+  mutex_.lock();
+  const auto acquired = std::chrono::steady_clock::now();
+  const LockKindIndex index = static_cast<LockKindIndex>(Kind);
+  RecordAcquisition(Kind, acquired - start);
+  thread_lock_state.acquired_at[index] = acquired;
+  thread_lock_state.owns[index] = true;
+}
+
+template <LockKind Kind>
+void InstrumentedMutex<Kind>::unlock() {
+  const LockKindIndex index = static_cast<LockKindIndex>(Kind);
+#ifdef NGLOG_ENABLE_LOCK_METRICS
+  if (thread_lock_state.owns[index]) {
+    const auto hold =
+        std::chrono::steady_clock::now() - thread_lock_state.acquired_at[index];
+    metrics.hold_nanoseconds[index].fetch_add(
+        static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(hold).count()),
+        std::memory_order_relaxed);
+  }
+#endif
+  thread_lock_state.owns[index] = false;
+  mutex_.unlock();
+}
+
+template <LockKind Kind>
+bool InstrumentedMutex<Kind>::try_lock() {
+  if (!mutex_.try_lock()) {
+    return false;
+  }
+  const auto acquired = std::chrono::steady_clock::now();
+  RecordAcquisition(Kind, std::chrono::steady_clock::duration::zero());
+  const LockKindIndex index = static_cast<LockKindIndex>(Kind);
+  thread_lock_state.acquired_at[index] = acquired;
+  thread_lock_state.owns[index] = true;
+  return true;
+}
+
+template <LockKind Kind>
+void InstrumentedSharedMutex<Kind>::lock() {
+  const auto start = std::chrono::steady_clock::now();
+  mutex_.lock();
+  const auto acquired = std::chrono::steady_clock::now();
+  const LockKindIndex index = static_cast<LockKindIndex>(Kind);
+  RecordAcquisition(Kind, acquired - start);
+  thread_lock_state.acquired_at[index] = acquired;
+  thread_lock_state.owns[index] = true;
+}
+
+template <LockKind Kind>
+void InstrumentedSharedMutex<Kind>::unlock() {
+  const LockKindIndex index = static_cast<LockKindIndex>(Kind);
+#ifdef NGLOG_ENABLE_LOCK_METRICS
+  if (thread_lock_state.owns[index]) {
+    const auto hold =
+        std::chrono::steady_clock::now() - thread_lock_state.acquired_at[index];
+    metrics.hold_nanoseconds[index].fetch_add(
+        static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(hold).count()),
+        std::memory_order_relaxed);
+  }
+#endif
+  thread_lock_state.owns[index] = false;
+  mutex_.unlock();
+}
+
+template <LockKind Kind>
+bool InstrumentedSharedMutex<Kind>::try_lock() {
+  if (!mutex_.try_lock()) {
+    return false;
+  }
+  const auto acquired = std::chrono::steady_clock::now();
+  RecordAcquisition(Kind, std::chrono::steady_clock::duration::zero());
+  const LockKindIndex index = static_cast<LockKindIndex>(Kind);
+  thread_lock_state.acquired_at[index] = acquired;
+  thread_lock_state.owns[index] = true;
+  return true;
+}
+
+template <LockKind Kind>
+void InstrumentedSharedMutex<Kind>::lock_shared() {
+  const auto start = std::chrono::steady_clock::now();
+  mutex_.lock_shared();
+  const auto acquired = std::chrono::steady_clock::now();
+  const LockKindIndex index = static_cast<LockKindIndex>(Kind);
+  RecordAcquisition(Kind, acquired - start);
+  thread_lock_state.acquired_at[index] = acquired;
+  thread_lock_state.owns[index] = true;
+}
+
+template <LockKind Kind>
+void InstrumentedSharedMutex<Kind>::unlock_shared() {
+  const LockKindIndex index = static_cast<LockKindIndex>(Kind);
+#ifdef NGLOG_ENABLE_LOCK_METRICS
+  if (thread_lock_state.owns[index]) {
+    const auto hold =
+        std::chrono::steady_clock::now() - thread_lock_state.acquired_at[index];
+    metrics.hold_nanoseconds[index].fetch_add(
+        static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(hold).count()),
+        std::memory_order_relaxed);
+  }
+#endif
+  thread_lock_state.owns[index] = false;
+  mutex_.unlock_shared();
+}
+
+template <LockKind Kind>
+bool InstrumentedSharedMutex<Kind>::try_lock_shared() {
+  if (!mutex_.try_lock_shared()) {
+    return false;
+  }
+  const auto acquired = std::chrono::steady_clock::now();
+  RecordAcquisition(Kind, std::chrono::steady_clock::duration::zero());
+  const LockKindIndex index = static_cast<LockKindIndex>(Kind);
+  thread_lock_state.acquired_at[index] = acquired;
+  thread_lock_state.owns[index] = true;
+  return true;
+}
+
+template class InstrumentedMutex<LockKind::kLog>;
+template class InstrumentedMutex<LockKind::kFile>;
+template class InstrumentedMutex<LockKind::kCleaner>;
+template class InstrumentedMutex<LockKind::kFatal>;
+template class InstrumentedSharedMutex<LockKind::kSink>;
+
+}  // namespace internal
+}  // namespace nglog

--- a/src/internal/lock_metrics.h
+++ b/src/internal/lock_metrics.h
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 The ng-log contributors
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Author: Sergiu Deitsch
+
+#ifndef NGLOG_INTERNAL_LOCK_METRICS_H_
+#define NGLOG_INTERNAL_LOCK_METRICS_H_
+
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <shared_mutex>
+
+#include "ng-log/export.h"
+
+namespace nglog {
+namespace internal {
+
+enum class LockKind {
+  kLog,
+  kFile,
+  kCleaner,
+  kFatal,
+  kSink,
+  kCount,
+};
+
+struct LockMetrics {
+  std::uint64_t acquisitions;
+  std::uint64_t contended_acquisitions;
+  std::uint64_t wait_nanoseconds;
+  std::uint64_t hold_nanoseconds;
+};
+
+NGLOG_EXPORT void ResetLockMetrics();
+NGLOG_EXPORT LockMetrics GetLockMetrics(LockKind kind);
+
+template <LockKind Kind>
+class InstrumentedMutex {
+ public:
+  void lock();
+  void unlock();
+  bool try_lock();
+
+  InstrumentedMutex() = default;
+  InstrumentedMutex(const InstrumentedMutex&) = delete;
+  InstrumentedMutex& operator=(const InstrumentedMutex&) = delete;
+
+ private:
+  std::mutex mutex_;
+};
+
+template <LockKind Kind>
+class InstrumentedSharedMutex {
+ public:
+  void lock();
+  void unlock();
+  bool try_lock();
+  void lock_shared();
+  void unlock_shared();
+  bool try_lock_shared();
+
+  InstrumentedSharedMutex() = default;
+  InstrumentedSharedMutex(const InstrumentedSharedMutex&) = delete;
+  InstrumentedSharedMutex& operator=(const InstrumentedSharedMutex&) = delete;
+
+ private:
+  std::shared_timed_mutex mutex_;
+};
+
+#ifdef NGLOG_ENABLE_LOCK_METRICS
+using LogMutex = InstrumentedMutex<LockKind::kLog>;
+using FileMutex = InstrumentedMutex<LockKind::kFile>;
+using CleanerMutex = InstrumentedMutex<LockKind::kCleaner>;
+using FatalMutex = InstrumentedMutex<LockKind::kFatal>;
+template <LockKind Kind>
+using MetricsSharedMutex = InstrumentedSharedMutex<Kind>;
+using CleanerConditionVariable = std::condition_variable_any;
+#else
+using LogMutex = std::mutex;
+using FileMutex = std::mutex;
+using CleanerMutex = std::mutex;
+using FatalMutex = std::mutex;
+using CleanerConditionVariable = std::condition_variable;
+#endif
+
+}  // namespace internal
+}  // namespace nglog
+
+#endif  // NGLOG_INTERNAL_LOCK_METRICS_H_

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -52,6 +52,7 @@
 #include <utility>
 
 #include "config.h"
+#include "internal/lock_metrics.h"
 #include "internal/source_location.h"
 #include "internal/style_recorder.h"
 #include "internal/styled_output.h"
@@ -299,10 +300,10 @@ struct LogMessageData {
 // changing the destination file for log messages of a given severity) also
 // lock this mutex.  Please be sure that anybody who might possibly need to
 // lock it does so.
-static std::mutex log_mutex;
+static internal::LogMutex log_mutex;
 
 // Number of messages sent at each severity.  Under log_mutex.
-int64 LogMessage::num_messages_[NUM_SEVERITIES] = {0, 0, 0, 0};
+std::atomic<int64> LogMessage::num_messages_[NUM_SEVERITIES]{};
 
 // Globally disable log writing (if disk is full)
 static bool stop_writing = false;
@@ -444,6 +445,12 @@ class LogFileObject : public base::Logger {
                  timestamp,  // Timestamp for this entry
              const char* message, size_t message_len) override;
 
+  // Called while the global logging mutex serializes the default logger.
+  void WriteUnlocked(bool force_flush,
+                     const std::chrono::system_clock::time_point& timestamp,
+                     const char* message, size_t message_len,
+                     std::unique_lock<internal::FileMutex>* lock);
+
   // Configuration options
   void SetBasename(const char* basename);
   void SetExtension(const char* ext);
@@ -455,7 +462,7 @@ class LogFileObject : public base::Logger {
   // It is the actual file length for the system loggers,
   // i.e., INFO, ERROR, etc.
   uint32 LogSize() override {
-    std::lock_guard<std::mutex> l{mutex_};
+    std::lock_guard<internal::FileMutex> l{mutex_};
     return file_length_;
   }
 
@@ -467,7 +474,7 @@ class LogFileObject : public base::Logger {
  private:
   static const uint32 kRolloverAttemptFrequency = 0x20;
 
-  std::mutex mutex_;
+  internal::FileMutex mutex_;
   bool base_filename_selected_;
   string base_filename_;
   string symlink_basename_;
@@ -549,8 +556,8 @@ class LogCleaner {
   // All members are guarded by mutex_. Scans run on the cleaner thread
   // without any lock held so that logging threads registering new log files
   // are never blocked on directory I/O.
-  std::mutex mutex_;
-  std::condition_variable cond_;
+  internal::CleanerMutex mutex_;
+  internal::CleanerConditionVariable cond_;
   std::thread thread_;  // joinable while enabled_ is true
   bool enabled_{false};
   std::chrono::minutes overdue_{
@@ -595,16 +602,21 @@ class LogDestination {
   LogDestination(LogSeverity severity, const char* base_filename);
 
  private:
-#if defined(__cpp_lib_shared_mutex) && (__cpp_lib_shared_mutex >= 201505L)
+#ifdef NGLOG_ENABLE_LOCK_METRICS
+  using SinkMutex = internal::MetricsSharedMutex<internal::LockKind::kSink>;
+  using SinkLock = std::lock_guard<SinkMutex>;
+#else
+#  if defined(__cpp_lib_shared_mutex) && (__cpp_lib_shared_mutex >= 201505L)
   // Use untimed shared mutex
   using SinkMutex = std::shared_mutex;
   using SinkLock = std::lock_guard<SinkMutex>;
-#else   // !(defined(__cpp_lib_shared_mutex) && (__cpp_lib_shared_mutex >=
-        // 201505L)) Fallback to timed shared mutex
+#  else   // !(defined(__cpp_lib_shared_mutex) && (__cpp_lib_shared_mutex >=
+          // 201505L)) Fallback to timed shared mutex
   using SinkMutex = std::shared_timed_mutex;
   using SinkLock = std::unique_lock<SinkMutex>;
-#endif  // defined(__cpp_lib_shared_mutex) && (__cpp_lib_shared_mutex >=
-        // 201505L)
+#  endif  // defined(__cpp_lib_shared_mutex) && (__cpp_lib_shared_mutex >=
+          // 201505L)
+#endif    // NGLOG_ENABLE_LOCK_METRICS
 
   friend std::default_delete<LogDestination>;
   ~LogDestination();
@@ -623,10 +635,18 @@ class LogDestination {
       LogSeverity severity,
       const std::chrono::system_clock::time_point& timestamp,
       const char* message, size_t len);
+  static void MaybeLogToLogfileLocked(
+      LogSeverity severity,
+      const std::chrono::system_clock::time_point& timestamp,
+      const char* message, size_t len);
   // Take a log message of a particular severity and log it to the file
   // for that severity and also for all files with severity less than
   // this severity.
   static void LogToAllLogfiles(
+      LogSeverity severity,
+      const std::chrono::system_clock::time_point& timestamp,
+      const char* message, size_t len);
+  static void LogToAllLogfilesLocked(
       LogSeverity severity,
       const std::chrono::system_clock::time_point& timestamp,
       const char* message, size_t len);
@@ -636,6 +656,20 @@ class LogDestination {
                          const char* base_filename, int line,
                          const LogMessageTime& time, const char* message,
                          size_t message_len);
+
+  static std::shared_ptr<const std::vector<LogSink*>> GetSinksForCall();
+  static void EndSinkCall(LogSink* sink);
+  static void WaitForSinkCalls(LogSink* sink);
+  static void WaitForAllSinkCalls();
+
+  class SinkCallGuard {
+   public:
+    explicit SinkCallGuard(LogSink* sink) : sink_(sink) {}
+    ~SinkCallGuard() { LogDestination::EndSinkCall(sink_); }
+
+   private:
+    LogSink* sink_;
+  };
 
   // Wait for all registered sinks via WaitTillSent
   // including the optional one in "data".
@@ -656,11 +690,14 @@ class LogDestination {
   static string hostname_;
 
   // arbitrary global logging destinations.
-  static std::unique_ptr<vector<LogSink*>> sinks_;
+  static std::shared_ptr<const vector<LogSink*>> sinks_;
 
   // Protects the vector sinks_,
   // but not the LogSink objects its elements reference.
   static SinkMutex sink_mutex_;
+  static std::mutex sink_call_mutex_;
+  static std::condition_variable sink_call_cond_;
+  static std::unordered_map<LogSink*, size_t> sink_call_counts_;
 
   // Disallow
   LogDestination(const LogDestination&) = delete;
@@ -674,8 +711,11 @@ std::underlying_type_t<LogSeverity> LogDestination::email_logging_severity_ =
 string LogDestination::addresses_;
 string LogDestination::hostname_;
 
-std::unique_ptr<vector<LogSink*>> LogDestination::sinks_;
+std::shared_ptr<const vector<LogSink*>> LogDestination::sinks_;
 LogDestination::SinkMutex LogDestination::sink_mutex_;
+std::mutex LogDestination::sink_call_mutex_;
+std::condition_variable LogDestination::sink_call_cond_;
+std::unordered_map<LogSink*, size_t> LogDestination::sink_call_counts_;
 
 /* static */
 const string& LogDestination::hostname() {
@@ -724,7 +764,7 @@ inline void LogDestination::FlushLogFilesUnsafe(int min_severity) {
 inline void LogDestination::FlushLogFiles(int min_severity) {
   // Prevent any subtle race conditions by wrapping a mutex lock around
   // all this stuff.
-  std::lock_guard<std::mutex> l{log_mutex};
+  std::lock_guard<::nglog::internal::LogMutex> l{log_mutex};
   for (int i = min_severity; i < NUM_SEVERITIES; i++) {
     LogDestination* log = log_destination(static_cast<LogSeverity>(i));
     if (log != nullptr) {
@@ -737,7 +777,7 @@ inline void LogDestination::SetLogDestination(LogSeverity severity,
                                               const char* base_filename) {
   // Prevent any subtle race conditions by wrapping a mutex lock around
   // all this stuff.
-  std::lock_guard<std::mutex> l{log_mutex};
+  std::lock_guard<::nglog::internal::LogMutex> l{log_mutex};
   log_destination(severity)->fileobject_.SetBasename(base_filename);
 }
 
@@ -745,7 +785,7 @@ inline void LogDestination::SetLogSymlink(LogSeverity severity,
                                           const char* symlink_basename) {
   CHECK_GE(severity, 0);
   CHECK_LT(severity, NUM_SEVERITIES);
-  std::lock_guard<std::mutex> l{log_mutex};
+  std::lock_guard<::nglog::internal::LogMutex> l{log_mutex};
   log_destination(severity)->fileobject_.SetSymlinkBasename(symlink_basename);
 }
 
@@ -753,25 +793,31 @@ inline void LogDestination::AddLogSink(LogSink* destination) {
   // Prevent any subtle race conditions by wrapping a mutex lock around
   // all this stuff.
   SinkLock l{sink_mutex_};
-  if (sinks_ == nullptr) sinks_ = std::make_unique<std::vector<LogSink*>>();
-  sinks_->push_back(destination);
+  std::vector<LogSink*> sinks = sinks_ ? *sinks_ : std::vector<LogSink*>{};
+  sinks.push_back(destination);
+  sinks_ = std::make_shared<const std::vector<LogSink*>>(std::move(sinks));
 }
 
 inline void LogDestination::RemoveLogSink(LogSink* destination) {
   // Prevent any subtle race conditions by wrapping a mutex lock around
   // all this stuff.
-  SinkLock l{sink_mutex_};
-  // This doesn't keep the sinks in order, but who cares?
-  if (sinks_) {
-    sinks_->erase(std::remove(sinks_->begin(), sinks_->end(), destination),
-                  sinks_->end());
+  {
+    SinkLock l{sink_mutex_};
+    // This doesn't keep the sinks in order, but who cares?
+    if (sinks_) {
+      std::vector<LogSink*> sinks = *sinks_;
+      sinks.erase(std::remove(sinks.begin(), sinks.end(), destination),
+                  sinks.end());
+      sinks_ = std::make_shared<const std::vector<LogSink*>>(std::move(sinks));
+    }
   }
+  WaitForSinkCalls(destination);
 }
 
 inline void LogDestination::SetLogFilenameExtension(const char* ext) {
   // Prevent any subtle race conditions by wrapping a mutex lock around
   // all this stuff.
-  std::lock_guard<std::mutex> l{log_mutex};
+  std::lock_guard<::nglog::internal::LogMutex> l{log_mutex};
   for (int severity = 0; severity < NUM_SEVERITIES; ++severity) {
     log_destination(static_cast<LogSeverity>(severity))
         ->fileobject_.SetExtension(ext);
@@ -781,7 +827,7 @@ inline void LogDestination::SetLogFilenameExtension(const char* ext) {
 inline void LogDestination::SetStderrLogging(LogSeverity min_severity) {
   // Prevent any subtle race conditions by wrapping a mutex lock around
   // all this stuff.
-  std::lock_guard<std::mutex> l{log_mutex};
+  std::lock_guard<internal::LogMutex> l{log_mutex};
   FLAGS_stderrthreshold = min_severity;
 }
 
@@ -799,7 +845,7 @@ inline void LogDestination::SetEmailLogging(LogSeverity min_severity,
                                             const char* addresses) {
   // Prevent any subtle race conditions by wrapping a mutex lock around
   // all this stuff.
-  std::lock_guard<std::mutex> l{log_mutex};
+  std::lock_guard<internal::LogMutex> l{log_mutex};
   LogDestination::email_logging_severity_ = min_severity;
   LogDestination::addresses_ = addresses;
 }
@@ -1164,6 +1210,20 @@ inline void LogDestination::MaybeLogToLogfile(
   destination->logger_->Write(should_flush, timestamp, message, len);
 }
 
+inline void LogDestination::MaybeLogToLogfileLocked(
+    LogSeverity severity,
+    const std::chrono::system_clock::time_point& timestamp, const char* message,
+    size_t len) {
+  const bool should_flush = severity > FLAGS_logbuflevel;
+  LogDestination* destination = log_destination(severity);
+  if (destination->logger_ == &destination->fileobject_) {
+    destination->fileobject_.WriteUnlocked(should_flush, timestamp, message,
+                                           len, nullptr);
+  } else {
+    destination->logger_->Write(should_flush, timestamp, message, len);
+  }
+}
+
 inline void LogDestination::LogToAllLogfiles(
     LogSeverity severity,
     const std::chrono::system_clock::time_point& timestamp, const char* message,
@@ -1180,26 +1240,47 @@ inline void LogDestination::LogToAllLogfiles(
   }
 }
 
+inline void LogDestination::LogToAllLogfilesLocked(
+    LogSeverity severity,
+    const std::chrono::system_clock::time_point& timestamp, const char* message,
+    size_t len) {
+  if (FLAGS_logtostdout) {
+    ColoredWriteToStdout(severity, message, len);
+  } else if (FLAGS_logtostderr) {
+    ColoredWriteToStderr(severity, message, len);
+  } else {
+    for (int i = severity; i >= 0; --i) {
+      LogDestination::MaybeLogToLogfileLocked(static_cast<LogSeverity>(i),
+                                              timestamp, message, len);
+    }
+  }
+}
+
 inline void LogDestination::LogToSinks(LogSeverity severity,
                                        const char* full_filename,
                                        const char* base_filename, int line,
                                        const LogMessageTime& time,
                                        const char* message,
                                        size_t message_len) {
-  std::shared_lock<SinkMutex> l{sink_mutex_};
-  if (sinks_) {
-    for (size_t i = sinks_->size(); i-- > 0;) {
-      (*sinks_)[i]->send(severity, full_filename, base_filename, line, time,
-                         message, message_len);
-    }
+  const auto sinks = GetSinksForCall();
+  if (!sinks) {
+    return;
+  }
+  for (size_t i = sinks->size(); i-- > 0;) {
+    LogSink* sink = (*sinks)[i];
+    SinkCallGuard guard{sink};
+    sink->send(severity, full_filename, base_filename, line, time, message,
+               message_len);
   }
 }
 
 inline void LogDestination::WaitForSinks(internal::LogMessageData* data) {
-  std::shared_lock<SinkMutex> l{sink_mutex_};
-  if (sinks_) {
-    for (size_t i = sinks_->size(); i-- > 0;) {
-      (*sinks_)[i]->WaitTillSent();
+  const auto sinks = GetSinksForCall();
+  if (sinks) {
+    for (size_t i = sinks->size(); i-- > 0;) {
+      LogSink* sink = (*sinks)[i];
+      SinkCallGuard guard{sink};
+      sink->WaitTillSent();
     }
   }
   const bool send_to_sink =
@@ -1208,6 +1289,43 @@ inline void LogDestination::WaitForSinks(internal::LogMessageData* data) {
   if (send_to_sink && data->sink_ != nullptr) {
     data->sink_->WaitTillSent();
   }
+}
+
+std::shared_ptr<const std::vector<LogSink*>> LogDestination::GetSinksForCall() {
+  std::shared_lock<SinkMutex> l{sink_mutex_};
+  const auto sinks = sinks_;
+  if (sinks) {
+    std::lock_guard<std::mutex> call_lock{sink_call_mutex_};
+    for (size_t i = sinks->size(); i-- > 0;) {
+      LogSink* sink = (*sinks)[i];
+      ++sink_call_counts_[sink];
+    }
+  }
+  return sinks;
+}
+
+void LogDestination::EndSinkCall(LogSink* sink) {
+  std::lock_guard<std::mutex> l{sink_call_mutex_};
+  auto it = sink_call_counts_.find(sink);
+  CHECK(it != sink_call_counts_.end());
+  CHECK_GT(it->second, 0U);
+  --it->second;
+  if (it->second == 0) {
+    sink_call_counts_.erase(it);
+    sink_call_cond_.notify_all();
+  }
+}
+
+void LogDestination::WaitForSinkCalls(LogSink* sink) {
+  std::unique_lock<std::mutex> l{sink_call_mutex_};
+  sink_call_cond_.wait(l, [sink] {
+    return sink_call_counts_.find(sink) == sink_call_counts_.end();
+  });
+}
+
+void LogDestination::WaitForAllSinkCalls() {
+  std::unique_lock<std::mutex> l{sink_call_mutex_};
+  sink_call_cond_.wait(l, [] { return sink_call_counts_.empty(); });
 }
 
 std::unique_ptr<LogDestination>
@@ -1225,8 +1343,11 @@ void LogDestination::DeleteLogDestinations() {
   for (auto& log_destination : log_destinations_) {
     log_destination.reset();
   }
-  SinkLock l{sink_mutex_};
-  sinks_.reset();
+  {
+    SinkLock l{sink_mutex_};
+    sinks_.reset();
+  }
+  WaitForAllSinkCalls();
 }
 
 namespace {
@@ -1269,12 +1390,12 @@ LogFileObject::LogFileObject(LogSeverity severity, const char* base_filename)
       start_time_(std::chrono::system_clock::now()) {}
 
 LogFileObject::~LogFileObject() {
-  std::lock_guard<std::mutex> l{mutex_};
+  std::lock_guard<internal::FileMutex> l{mutex_};
   file_ = nullptr;
 }
 
 void LogFileObject::SetBasename(const char* basename) {
-  std::lock_guard<std::mutex> l{mutex_};
+  std::lock_guard<internal::FileMutex> l{mutex_};
   base_filename_selected_ = true;
   if (base_filename_ != basename) {
     // Get rid of old log file since we are changing names
@@ -1287,7 +1408,7 @@ void LogFileObject::SetBasename(const char* basename) {
 }
 
 void LogFileObject::SetExtension(const char* ext) {
-  std::lock_guard<std::mutex> l{mutex_};
+  std::lock_guard<internal::FileMutex> l{mutex_};
   if (filename_extension_ != ext) {
     // Get rid of old log file since we are changing names
     if (file_ != nullptr) {
@@ -1299,12 +1420,12 @@ void LogFileObject::SetExtension(const char* ext) {
 }
 
 void LogFileObject::SetSymlinkBasename(const char* symlink_basename) {
-  std::lock_guard<std::mutex> l{mutex_};
+  std::lock_guard<internal::FileMutex> l{mutex_};
   symlink_basename_ = symlink_basename;
 }
 
 void LogFileObject::Flush() {
-  std::lock_guard<std::mutex> l{mutex_};
+  std::lock_guard<internal::FileMutex> l{mutex_};
   FlushUnlocked(std::chrono::system_clock::now());
 }
 
@@ -1442,7 +1563,17 @@ bool LogFileObject::CreateLogfile(const string& time_pid_string) {
 void LogFileObject::Write(
     bool force_flush, const std::chrono::system_clock::time_point& timestamp,
     const char* message, size_t message_len) {
-  std::unique_lock<std::mutex> l{mutex_};
+  std::unique_lock<internal::FileMutex> l{mutex_};
+  WriteUnlocked(force_flush, timestamp, message, message_len, &l);
+}
+
+void LogFileObject::WriteUnlocked(
+    bool force_flush, const std::chrono::system_clock::time_point& timestamp,
+    const char* message, size_t message_len,
+    std::unique_lock<internal::FileMutex>* lock) {
+#if !defined(NGLOG_OS_LINUX) || !defined(HAVE_POSIX_FADVISE)
+  (void)lock;
+#endif
 
   // We don't log if the base_name_ is "" (which means "don't write")
   if (base_filename_selected_ && base_filename_.empty()) {
@@ -1641,9 +1772,13 @@ void LogFileObject::Write(
         // the original descriptor.
         FileDescriptor fd{fcntl(fileno(file_.get()), F_DUPFD_CLOEXEC, 0)};
         if (fd) {
-          l.unlock();
+          if (lock != nullptr) {
+            lock->unlock();
+          }
           posix_fadvise(fd.get(), offset, length, POSIX_FADV_DONTNEED);
-          l.lock();
+          if (lock != nullptr) {
+            lock->lock();
+          }
         } else {
           // Duplicating the descriptor failed. Fall back to advising while
           // holding the lock.
@@ -1664,7 +1799,7 @@ LogCleaner::~LogCleaner() { Stop(); }
 void LogCleaner::Stop() {
   std::thread cleaner;
   {
-    std::lock_guard<std::mutex> l{mutex_};
+    std::lock_guard<internal::CleanerMutex> l{mutex_};
     enabled_ = false;
     cleaner = std::move(thread_);
   }
@@ -1676,7 +1811,7 @@ void LogCleaner::Stop() {
 
 void LogCleaner::Enable(const std::chrono::minutes& overdue) {
   {
-    std::lock_guard<std::mutex> l{mutex_};
+    std::lock_guard<internal::CleanerMutex> l{mutex_};
     overdue_ = overdue;
     if (!std::exchange(enabled_, true)) {
       // Logs may have become overdue while the cleaner was disabled: make all
@@ -1701,7 +1836,7 @@ void LogCleaner::Disable() {
   std::unordered_map<std::string, LogFilePattern> patterns;
   std::chrono::minutes overdue;
   {
-    std::lock_guard<std::mutex> l{mutex_};
+    std::lock_guard<internal::CleanerMutex> l{mutex_};
     patterns = patterns_;
     overdue = overdue_;
   }
@@ -1724,7 +1859,7 @@ void LogCleaner::AddLogFilePattern(bool base_filename_selected,
   assert(!base_filename_selected || !base_filename.empty());
 
   {
-    std::lock_guard<std::mutex> l{mutex_};
+    std::lock_guard<internal::CleanerMutex> l{mutex_};
     LogFilePattern& pattern = patterns_[base_filename];
     pattern.base_filename_selected = base_filename_selected;
     pattern.filename_extension = filename_extension;
@@ -1744,7 +1879,7 @@ void LogCleaner::Worker() {
     std::chrono::minutes overdue{};
 
     {
-      std::unique_lock<std::mutex> l{mutex_};
+      std::unique_lock<internal::CleanerMutex> l{mutex_};
       if (!enabled_) {
         return;
       }
@@ -1980,7 +2115,7 @@ bool LogCleaner::IsLogLastModifiedOver(
 // the data from the first call, we allocate two sets of space.  One
 // for exclusive use by the first thread, and one for shared use by
 // all other threads.
-static std::mutex fatal_msg_lock;
+static internal::FatalMutex fatal_msg_lock;
 static internal::CrashReason crash_reason;
 static bool fatal_msg_exclusive = true;
 static internal::LogMessageData fatal_msg_data_exclusive;
@@ -2071,7 +2206,7 @@ void LogMessage::Init(const char* file, int line, LogSeverity severity,
 #endif  // defined(NGLOG_THREAD_LOCAL_STORAGE)
     data_->first_fatal_ = false;
   } else {
-    std::lock_guard<std::mutex> l{fatal_msg_lock};
+    std::lock_guard<internal::FatalMutex> l{fatal_msg_lock};
     if (fatal_msg_exclusive) {
       fatal_msg_exclusive = false;
       data_ = &fatal_msg_data_exclusive;
@@ -2241,7 +2376,7 @@ void LogMessage::Flush() {
   // Prevent any subtle race conditions by wrapping a mutex lock around
   // the actual logging action per se.
   {
-    std::lock_guard<std::mutex> l{log_mutex};
+    std::lock_guard<internal::LogMutex> l{log_mutex};
     (this->*(data_->send_method_))();
     ++num_messages_[static_cast<int>(data_->severity_)];
   }
@@ -2319,9 +2454,9 @@ void LogMessage::SendToLog() EXCLUSIVE_LOCKS_REQUIRED(log_mutex) {
         (data_->num_chars_to_log_ - data_->num_prefix_chars_ - 1));
   } else {
     // log this message to all log files of severity <= severity_
-    LogDestination::LogToAllLogfiles(data_->severity_, time_.when(),
-                                     data_->message_text_,
-                                     data_->num_chars_to_log_);
+    LogDestination::LogToAllLogfilesLocked(data_->severity_, time_.when(),
+                                           data_->message_text_,
+                                           data_->num_chars_to_log_);
 
     LogDestination::MaybeLogToStderr(*data_);
     LogDestination::MaybeLogToEmail(data_->severity_, data_->message_text_,
@@ -2471,19 +2606,18 @@ void LogMessage::SendToSyslogAndLog() {
 }
 
 base::Logger* base::GetLogger(LogSeverity severity) {
-  std::lock_guard<std::mutex> l{log_mutex};
+  std::lock_guard<internal::LogMutex> l{log_mutex};
   return LogDestination::log_destination(severity)->GetLoggerImpl();
 }
 
 void base::SetLogger(LogSeverity severity, base::Logger* logger) {
-  std::lock_guard<std::mutex> l{log_mutex};
+  std::lock_guard<internal::LogMutex> l{log_mutex};
   LogDestination::log_destination(severity)->SetLoggerImpl(logger);
 }
 
-// L < log_mutex.  Acquires and releases mutex_.
+// L < log_mutex.
 int64 LogMessage::num_messages(int severity) {
-  std::lock_guard<std::mutex> l{log_mutex};
-  return num_messages_[severity];
+  return num_messages_[severity].load(std::memory_order_relaxed);
 }
 
 // Output the COUNTER value. This is only valid if ostream is a
@@ -2586,7 +2720,7 @@ namespace internal {
 
 bool GetExitOnDFatal();
 bool GetExitOnDFatal() {
-  std::lock_guard<std::mutex> l{log_mutex};
+  std::lock_guard<::nglog::internal::LogMutex> l{log_mutex};
   return exit_on_dfatal;
 }
 
@@ -2602,7 +2736,7 @@ bool GetExitOnDFatal() {
 // these differences are acceptable.
 void SetExitOnDFatal(bool value);
 void SetExitOnDFatal(bool value) {
-  std::lock_guard<std::mutex> l{log_mutex};
+  std::lock_guard<::nglog::internal::LogMutex> l{log_mutex};
   exit_on_dfatal = value;
 }
 

--- a/src/logging_benchmark.cc
+++ b/src/logging_benchmark.cc
@@ -32,6 +32,10 @@
 
 #include <benchmark/benchmark.h>
 
+#include <cstdint>
+#include <cstdio>
+
+#include "internal/lock_metrics.h"
 #include "ng-log/logging.h"
 
 #ifdef NGLOG_USE_GFLAGS
@@ -42,6 +46,28 @@ using namespace GFLAGS_NAMESPACE;
 using namespace nglog;
 
 namespace {
+
+constexpr int kOneThread = 1;
+constexpr int kTwoThreads = 2;
+constexpr int kEightThreads = 8;
+constexpr int kSixteenThreads = 16;
+
+class NullLogger : public base::Logger {
+ public:
+  void Write(bool /* force_flush */,
+             const std::chrono::system_clock::time_point& /* timestamp */,
+             const char* /* message */, size_t /* length */) override {}
+  void Flush() override {}
+  uint32 LogSize() override { return 0; }
+};
+
+class NullSink : public LogSink {
+ public:
+  void send(LogSeverity /* severity */, const char* /* full_filename */,
+            const char* /* base_filename */, int /* line */,
+            const LogMessageTime& /* logmsgtime */, const char* /* message */,
+            size_t /* message_len */) override {}
+};
 
 // Non-constant so the compiler cannot fold the comparisons below away.
 int x = -1;
@@ -111,19 +137,98 @@ void BM_vlog(benchmark::State& state) {
 }
 BENCHMARK(BM_vlog);
 
+void BM_ConcurrentLog(benchmark::State& state) {
+  for (auto _ : state) {
+    LOG(INFO) << "test message";
+  }
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()));
+}
+BENCHMARK(BM_ConcurrentLog)
+    ->Threads(kOneThread)
+    ->Threads(kTwoThreads)
+    ->Threads(kEightThreads)
+    ->Threads(kSixteenThreads);
+
+void BM_ConcurrentLogToSink(benchmark::State& state) {
+  static NullSink sink;
+  for (auto _ : state) {
+    LOG_TO_SINK(&sink, INFO) << "test message";
+  }
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()));
+}
+BENCHMARK(BM_ConcurrentLogToSink)
+    ->Threads(kOneThread)
+    ->Threads(kTwoThreads)
+    ->Threads(kEightThreads)
+    ->Threads(kSixteenThreads);
+
+void BM_ConcurrentMessageCount(benchmark::State& state) {
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(LogMessage::num_messages(NGLOG_INFO));
+  }
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()));
+}
+BENCHMARK(BM_ConcurrentMessageCount)
+    ->Threads(kOneThread)
+    ->Threads(kTwoThreads)
+    ->Threads(kEightThreads)
+    ->Threads(kSixteenThreads);
+
+void BM_ConcurrentLoggerLookup(benchmark::State& state) {
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(base::GetLogger(NGLOG_INFO));
+  }
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()));
+}
+BENCHMARK(BM_ConcurrentLoggerLookup)
+    ->Threads(kOneThread)
+    ->Threads(kTwoThreads)
+    ->Threads(kEightThreads)
+    ->Threads(kSixteenThreads);
+
+void PrintLockMetrics() {
+#ifdef NGLOG_ENABLE_LOCK_METRICS
+  for (const internal::LockKind kind :
+       {internal::LockKind::kLog, internal::LockKind::kFile,
+        internal::LockKind::kCleaner, internal::LockKind::kFatal,
+        internal::LockKind::kSink}) {
+    const internal::LockMetrics metrics = internal::GetLockMetrics(kind);
+    std::fprintf(
+        stderr,
+        "lock kind %d acquisitions=%llu contended=%llu "
+        "wait_ns=%llu hold_ns=%llu\n",
+        static_cast<int>(kind),
+        static_cast<unsigned long long>(metrics.acquisitions),
+        static_cast<unsigned long long>(metrics.contended_acquisitions),
+        static_cast<unsigned long long>(metrics.wait_nanoseconds),
+        static_cast<unsigned long long>(metrics.hold_nanoseconds));
+  }
+#endif
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
   InitializeLogging(argv[0]);
-#ifdef NGLOG_USE_GFLAGS
-  ParseCommandLineFlags(&argc, &argv, true);
-#endif
-
   benchmark::Initialize(&argc, argv);
   if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
     return 1;
   }
+#ifdef NGLOG_USE_GFLAGS
+  ParseCommandLineFlags(&argc, &argv, true);
+#endif
+
+  FLAGS_logtostderr = false;
+  FLAGS_logtostdout = false;
+  base::Logger* old_logger = base::GetLogger(NGLOG_INFO);
+  base::SetLogger(NGLOG_INFO, new NullLogger);
+  NullSink registered_sink;
+  AddLogSink(&registered_sink);
+  internal::ResetLockMetrics();
   benchmark::RunSpecifiedBenchmarks();
   benchmark::Shutdown();
+  PrintLockMetrics();
+  RemoveLogSink(&registered_sink);
+  base::SetLogger(NGLOG_INFO, old_logger);
   return 0;
 }

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -33,9 +33,11 @@
 #include <fcntl.h>
 
 #include <chrono>
+#include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
+#include <future>
 #include <iomanip>
 #include <iostream>
 #include <memory>
@@ -64,6 +66,7 @@
 #include <gtest/gtest.h>
 
 #include "base/commandlineflags.h"
+#include "internal/lock_metrics.h"
 #include "mock-log.h"
 #include "ng-log/logging.h"
 #include "ng-log/raw_logging.h"
@@ -518,6 +521,41 @@ class TestLogSinkImpl : public LogSink {
     errors.push_back(ToString(severity, base_filename, line, logmsgtime,
                               message, message_len));
   }
+};
+
+class BlockingLogger : public base::Logger {
+ public:
+  void Write(bool /* force_flush */,
+             const std::chrono::system_clock::time_point&,
+             const char* /* message */, size_t /* length */) override {
+    std::unique_lock<std::mutex> lock(mutex_);
+    entered_ = true;
+    condition_.notify_all();
+    condition_.wait(lock, [this] { return released_; });
+  }
+
+  void Flush() override {}
+  uint32 LogSize() override { return 0; }
+
+  bool WaitUntilEntered() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return condition_.wait_for(lock, std::chrono::seconds(1),
+                               [this] { return entered_; });
+  }
+
+  void Release() {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      released_ = true;
+    }
+    condition_.notify_all();
+  }
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable condition_;
+  bool entered_{false};
+  bool released_{false};
 };
 
 void TestLogSink() {
@@ -1219,6 +1257,59 @@ TEST(Logging, DropLogMemoryConcurrentWriters) {
   FLAGS_drop_log_memory = old_drop_log_memory;
   FLAGS_logbufsecs = old_logbufsecs;
 #endif
+}
+
+TEST(Logging, MessageCountDoesNotWaitForLogger) {
+  FlagSaver saver;
+  FLAGS_logtostderr = false;
+  FLAGS_logtostdout = false;
+
+  base::Logger* old_logger = base::GetLogger(NGLOG_INFO);
+  auto* logger = new BlockingLogger;
+  base::SetLogger(NGLOG_INFO, logger);
+
+  std::thread logging_thread([] { LOG(INFO) << "blocked logger"; });
+  ASSERT_TRUE(logger->WaitUntilEntered());
+
+  std::future<int64> message_count = std::async(
+      std::launch::async, [] { return LogMessage::num_messages(NGLOG_INFO); });
+  EXPECT_EQ(message_count.wait_for(std::chrono::milliseconds(100)),
+            std::future_status::ready);
+
+  logger->Release();
+  logging_thread.join();
+  EXPECT_EQ(message_count.wait_for(std::chrono::seconds(1)),
+            std::future_status::ready);
+  if (message_count.valid()) {
+    message_count.get();
+  }
+  base::SetLogger(NGLOG_INFO, old_logger);
+}
+
+TEST(Logging, DefaultFileDispatchDoesNotRelockFile) {
+  FlagSaver saver;
+  FLAGS_logtostderr = false;
+  FLAGS_logtostdout = false;
+  FLAGS_timestamp_in_logfile_name = false;
+
+  const std::string destination =
+      TestTmpDir() + "/logging_test_default_file_dispatch";
+  DeleteFiles(destination + "*");
+  SetLogDestination(NGLOG_INFO, destination.c_str());
+
+#ifdef NGLOG_ENABLE_LOCK_METRICS
+  internal::ResetLockMetrics();
+#endif
+  LOG(INFO) << "default file dispatch";
+
+#ifdef NGLOG_ENABLE_LOCK_METRICS
+  const internal::LockMetrics metrics =
+      internal::GetLockMetrics(internal::LockKind::kFile);
+  EXPECT_EQ(metrics.acquisitions, 0U);
+#endif
+
+  LogToStderr();
+  DeleteFiles(destination + "*");
 }
 
 struct RecordDeletionLogger : public base::Logger {

--- a/src/mock-log_unittest.cc
+++ b/src/mock-log_unittest.cc
@@ -37,7 +37,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
 #include <string>
+#include <thread>
 
 namespace {
 
@@ -48,6 +52,8 @@ using testing::EndsWith;
 using testing::InSequence;
 using testing::InvokeWithoutArgs;
 using testing::StrEq;
+
+constexpr std::chrono::milliseconds kSinkCallbackTimeout{100};
 
 // Tests that ScopedMockLog intercepts LOG()s when it's alive.
 TEST(ScopedMockLogTest, InterceptsLog) {
@@ -94,6 +100,106 @@ TEST(ScopedMockLogTest, LogDuringIntercept) {
   EXPECT_CALL(log, Log(NGLOG_INFO, StrEq(__FILE__),
                        StrEq("Logging the entire forest...")));
   LogBranch();
+}
+
+TEST(ScopedMockLogTest, SendsToSinksInReverseRegistrationOrder) {
+  ScopedMockLog first;
+  ScopedMockLog second;
+  InSequence s;
+  EXPECT_CALL(second, Log(NGLOG_INFO, StrEq(__FILE__),
+                          StrEq("Logging in registration order.")));
+  EXPECT_CALL(first, Log(NGLOG_INFO, StrEq(__FILE__),
+                         StrEq("Logging in registration order.")));
+
+  LOG(INFO) << "Logging in registration order.";
+}
+
+class ReentrantLogSink : public nglog::LogSink {
+ public:
+  ~ReentrantLogSink() override { JoinThreads(); }
+
+  void send(nglog::LogSeverity /* severity */, const char* /* full_filename */,
+            const char* /* base_filename */, int /* line */,
+            const nglog::LogMessageTime& /* time */, const char* /* message */,
+            std::size_t /* message_len */) override {}
+
+  void WaitTillSent() override {
+    {
+      std::lock_guard<std::mutex> lock{mutex_};
+      if (started_) {
+        return;
+      }
+      started_ = true;
+    }
+
+    add_thread_ = std::thread([this] {
+      {
+        std::lock_guard<std::mutex> lock{mutex_};
+        add_started_ = true;
+      }
+      condition_.notify_all();
+      nglog::AddLogSink(this);
+      {
+        std::lock_guard<std::mutex> lock{mutex_};
+        add_finished_ = true;
+      }
+      condition_.notify_all();
+    });
+
+    {
+      std::unique_lock<std::mutex> lock{mutex_};
+      condition_.wait(lock, [this] { return add_started_; });
+    }
+
+    log_thread_ = std::thread([this] {
+      LOG(INFO) << "Logging from a sink callback.";
+      {
+        std::lock_guard<std::mutex> lock{mutex_};
+        log_finished_ = true;
+      }
+      condition_.notify_all();
+    });
+
+    std::unique_lock<std::mutex> lock{mutex_};
+    callback_completed_ =
+        condition_.wait_for(lock, kSinkCallbackTimeout,
+                            [this] { return add_finished_ && log_finished_; });
+  }
+
+  bool CallbackCompleted() const {
+    std::lock_guard<std::mutex> lock{mutex_};
+    return callback_completed_;
+  }
+
+ private:
+  void JoinThreads() {
+    if (add_thread_.joinable()) {
+      add_thread_.join();
+    }
+    if (log_thread_.joinable()) {
+      log_thread_.join();
+    }
+  }
+
+  mutable std::mutex mutex_;
+  std::condition_variable condition_;
+  std::thread add_thread_;
+  std::thread log_thread_;
+  bool started_{false};
+  bool add_started_{false};
+  bool add_finished_{false};
+  bool log_finished_{false};
+  bool callback_completed_{false};
+};
+
+TEST(ScopedMockLogTest, SinkCallbackCanLogWhileSinksChange) {
+  ReentrantLogSink sink;
+  nglog::AddLogSink(&sink);
+
+  LOG(INFO) << "Start sink callback.";
+
+  EXPECT_TRUE(sink.CallbackCompleted());
+  nglog::RemoveLogSink(&sink);
 }
 
 }  // namespace

--- a/src/ng-log/logging.h
+++ b/src/ng-log/logging.h
@@ -1344,7 +1344,7 @@ class NGLOG_EXPORT LogMessage {
   void RecordCrashReason(internal::CrashReason* reason);
 
   // Counts of messages sent at each priority:
-  static int64 num_messages_[NUM_SEVERITIES];  // under log_mutex
+  static std::atomic<int64> num_messages_[NUM_SEVERITIES];
 
   // We keep the data in a separate struct so that each instance of
   // LogMessage uses less stack space.


### PR DESCRIPTION
Reduce redundant locking in default file dispatch and make message count queries independent of the logging mutex. Move sink callbacks outside the sink registry lock while tracking active calls to preserve sink lifetime, reentrant logging, and registration order. Add opt-in lock metrics and concurrent benchmarks to measure the locking changes.