### PR TITLE
perf: reduce sink contention in logging

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -16,6 +16,7 @@
 - Improve suppressed logging performance by avoiding message construction and
   reduce overhead when formatting default prefixes
 - Improve logging throughput for applications that log from multiple threads
+- Allow sink callbacks to run concurrently and safely perform nested logging
 - Include the current thread name in failure signal reports when available
 
 !!! warning "Compatibility"

--- a/docs/sinks.md
+++ b/docs/sinks.md
@@ -22,9 +22,12 @@ class LogSink {
 The user must implement `#!cpp nglog::LogSink::send`, which is called by the
 library every time a message is logged.
 
-!!! warning "Possible deadlock due to nested logging"
-    This method can't use `LOG()` or `CHECK()` as logging system mutex(s) are
-    held during this call.
+Sink callbacks may run concurrently for different messages. They must be
+thread-safe and may use `LOG()` or `CHECK()` for nested logging.
+
+Callbacks for the sinks associated with one message retain the library's
+existing sink order. No ordering is guaranteed between callbacks for different
+messages.
 
 ## Registering Log Sinks
 

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -34,6 +34,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cassert>
 #include <chrono>
 #include <condition_variable>
@@ -691,6 +692,7 @@ class LogDestination {
 
   // arbitrary global logging destinations.
   static std::shared_ptr<const vector<LogSink*>> sinks_;
+  static std::atomic<bool> sinks_present_;
 
   // Protects the vector sinks_,
   // but not the LogSink objects its elements reference.
@@ -712,6 +714,7 @@ string LogDestination::addresses_;
 string LogDestination::hostname_;
 
 std::shared_ptr<const vector<LogSink*>> LogDestination::sinks_;
+std::atomic<bool> LogDestination::sinks_present_{false};
 LogDestination::SinkMutex LogDestination::sink_mutex_;
 std::mutex LogDestination::sink_call_mutex_;
 std::condition_variable LogDestination::sink_call_cond_;
@@ -796,6 +799,7 @@ inline void LogDestination::AddLogSink(LogSink* destination) {
   std::vector<LogSink*> sinks = sinks_ ? *sinks_ : std::vector<LogSink*>{};
   sinks.push_back(destination);
   sinks_ = std::make_shared<const std::vector<LogSink*>>(std::move(sinks));
+  sinks_present_.store(true, std::memory_order_release);
 }
 
 inline void LogDestination::RemoveLogSink(LogSink* destination) {
@@ -809,6 +813,7 @@ inline void LogDestination::RemoveLogSink(LogSink* destination) {
       sinks.erase(std::remove(sinks.begin(), sinks.end(), destination),
                   sinks.end());
       sinks_ = std::make_shared<const std::vector<LogSink*>>(std::move(sinks));
+      sinks_present_.store(!sinks_->empty(), std::memory_order_release);
     }
   }
   WaitForSinkCalls(destination);
@@ -1292,6 +1297,10 @@ inline void LogDestination::WaitForSinks(internal::LogMessageData* data) {
 }
 
 std::shared_ptr<const std::vector<LogSink*>> LogDestination::GetSinksForCall() {
+  if (!sinks_present_.load(std::memory_order_acquire)) {
+    return nullptr;
+  }
+
   std::shared_lock<SinkMutex> l{sink_mutex_};
   const auto sinks = sinks_;
   if (sinks) {
@@ -2373,14 +2382,45 @@ void LogMessage::Flush() {
   }
   data_->message_text_[data_->num_chars_to_log_] = '\0';
 
-  // Prevent any subtle race conditions by wrapping a mutex lock around
-  // the actual logging action per se.
+  const auto send_method = data_->send_method_;
+  const bool send_to_sink = send_method == &LogMessage::SendToSink ||
+                            send_method == &LogMessage::SendToSinkAndLog;
+  const bool send_to_registered_sinks =
+      send_method == &LogMessage::SendToLog ||
+      send_method == &LogMessage::SendToSyslogAndLog ||
+      send_method == &LogMessage::SendToSinkAndLog ||
+      send_method == &LogMessage::WriteToStringAndLog ||
+      (send_method == &LogMessage::SaveOrSendToLog &&
+       data_->outvec_ == nullptr);
+  const bool wait_for_sinks_before_count = send_to_registered_sinks &&
+                                           data_->severity_ == NGLOG_FATAL &&
+                                           exit_on_dfatal;
+
+  if (send_to_sink) {
+    SendToSink();
+  }
+
+  // Protect the shared logging destinations while dispatching the message.
   {
     std::lock_guard<internal::LogMutex> l{log_mutex};
-    (this->*(data_->send_method_))();
-    ++num_messages_[static_cast<int>(data_->severity_)];
+    if (send_method == &LogMessage::SendToSinkAndLog) {
+      SendToLog();
+    } else if (send_method != &LogMessage::SendToSink) {
+      (this->*send_method)();
+    }
   }
-  LogDestination::WaitForSinks(data_);
+
+  if (send_to_registered_sinks) {
+    SendToRegisteredSinks();
+  }
+
+  if (wait_for_sinks_before_count) {
+    LogDestination::WaitForSinks(data_);
+  }
+  ++num_messages_[static_cast<int>(data_->severity_)];
+  if (!wait_for_sinks_before_count) {
+    LogDestination::WaitForSinks(data_);
+  }
 
   if (append_newline) {
     // Fix the ostrstream back how it was before we screwed with it.
@@ -2447,11 +2487,6 @@ void LogMessage::SendToLog() EXCLUSIVE_LOCKS_REQUIRED(log_mutex) {
       ColoredWriteToStderrWithFields(*data_);
     }
 
-    // this could be protected by a flag if necessary.
-    LogDestination::LogToSinks(
-        data_->severity_, data_->fullname_, data_->basename_, data_->line_,
-        time_, data_->message_text_ + data_->num_prefix_chars_,
-        (data_->num_chars_to_log_ - data_->num_prefix_chars_ - 1));
   } else {
     // log this message to all log files of severity <= severity_
     LogDestination::LogToAllLogfilesLocked(data_->severity_, time_.when(),
@@ -2461,10 +2496,6 @@ void LogMessage::SendToLog() EXCLUSIVE_LOCKS_REQUIRED(log_mutex) {
     LogDestination::MaybeLogToStderr(*data_);
     LogDestination::MaybeLogToEmail(data_->severity_, data_->message_text_,
                                     data_->num_chars_to_log_);
-    LogDestination::LogToSinks(
-        data_->severity_, data_->fullname_, data_->basename_, data_->line_,
-        time_, data_->message_text_ + data_->num_prefix_chars_,
-        (data_->num_chars_to_log_ - data_->num_prefix_chars_ - 1));
     // NOTE: -1 removes trailing \n
   }
 
@@ -2494,8 +2525,6 @@ void LogMessage::SendToLog() EXCLUSIVE_LOCKS_REQUIRED(log_mutex) {
         }
       }
     }
-
-    LogDestination::WaitForSinks(data_);
   }
 }
 
@@ -2536,8 +2565,7 @@ void LogMessage::Fail() {
   std::abort();
 }
 
-// L >= log_mutex (callers must hold the log_mutex).
-void LogMessage::SendToSink() EXCLUSIVE_LOCKS_REQUIRED(log_mutex) {
+void LogMessage::SendToSink() {
   if (data_->sink_ != nullptr) {
     RAW_DCHECK(data_->num_chars_to_log_ > 0 &&
                    data_->message_text_[data_->num_chars_to_log_ - 1] == '\n',
@@ -2547,6 +2575,13 @@ void LogMessage::SendToSink() EXCLUSIVE_LOCKS_REQUIRED(log_mutex) {
         time_, data_->message_text_ + data_->num_prefix_chars_,
         (data_->num_chars_to_log_ - data_->num_prefix_chars_ - 1));
   }
+}
+
+void LogMessage::SendToRegisteredSinks() {
+  LogDestination::LogToSinks(
+      data_->severity_, data_->fullname_, data_->basename_, data_->line_, time_,
+      data_->message_text_ + data_->num_prefix_chars_,
+      (data_->num_chars_to_log_ - data_->num_prefix_chars_ - 1));
 }
 
 // L >= log_mutex (callers must hold the log_mutex).

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -32,6 +32,7 @@
 
 #include <fcntl.h>
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <cstdio>
@@ -558,6 +559,63 @@ class BlockingLogger : public base::Logger {
   bool released_{false};
 };
 
+class ReentrantLogSink : public LogSink {
+ public:
+  void send(LogSeverity /* severity */, const char* /* full_filename */,
+            const char* /* base_filename */, int /* line */,
+            const LogMessageTime& /* time */, const char* /* message */,
+            size_t /* message_len */) override {
+    bool expected = false;
+    if (!nested_started_.compare_exchange_strong(expected, true)) {
+      return;
+    }
+
+    const std::shared_ptr<State> state = state_;
+    std::thread nested_thread([state] {
+      LOG(INFO) << "Nested log from sink callback.";
+      {
+        std::lock_guard<std::mutex> lock(state->mutex);
+        state->nested_finished = true;
+      }
+      state->condition.notify_all();
+    });
+    nested_thread.detach();
+
+    std::unique_lock<std::mutex> lock(state->mutex);
+    const bool nested_completed = state->condition.wait_for(
+        lock, kSinkCallbackTimeout, [state] { return state->nested_finished; });
+    state->nested_completed_during_callback = nested_completed;
+    lock.unlock();
+    state->condition.notify_all();
+  }
+
+  bool WaitForNestedCompletion() const {
+    std::unique_lock<std::mutex> lock(state_->mutex);
+    return state_->condition.wait_for(
+        lock, kSinkCallbackTimeout, [this] { return state_->nested_finished; });
+  }
+
+  bool NestedCompletedDuringCallback() const {
+    std::lock_guard<std::mutex> lock(state_->mutex);
+    return state_->nested_completed_during_callback;
+  }
+
+ private:
+  static constexpr std::chrono::seconds kSinkCallbackTimeout{1};
+
+  struct State {
+    std::mutex mutex;
+    std::condition_variable condition;
+    bool nested_finished{false};
+    bool nested_completed_during_callback{false};
+  };
+
+  std::atomic<bool> nested_started_{false};
+  std::shared_ptr<State> state_{std::make_shared<State>()};
+};
+
+constexpr std::chrono::seconds ReentrantLogSink::kSinkCallbackTimeout;
+
 void TestLogSink() {
   TestLogSinkImpl sink;
   LogSink* no_sink = nullptr;
@@ -601,6 +659,45 @@ void TestLogSink() {
     LogMessage("foo", LogMessage::kNoLogPrefix, NGLOG_INFO).stream() << error;
   }
 }
+
+TEST(Logging, RegisteredSinkCanLogDuringSend) {
+  ReentrantLogSink sink;
+  AddLogSink(&sink);
+
+  LOG(INFO) << "Log to registered reentrant sink.";
+
+  RemoveLogSink(&sink);
+  EXPECT_TRUE(sink.WaitForNestedCompletion());
+  EXPECT_TRUE(sink.NestedCompletedDuringCallback());
+}
+
+TEST(Logging, DirectSinkCanLogDuringSend) {
+  FlagSaver saver;
+  FLAGS_logtostderr = true;
+
+  ReentrantLogSink sink;
+  LOG_TO_SINK_BUT_NOT_TO_LOGFILE(&sink, INFO)
+      << "Log to direct reentrant sink.";
+
+  EXPECT_TRUE(sink.WaitForNestedCompletion());
+  EXPECT_TRUE(sink.NestedCompletedDuringCallback());
+}
+
+#ifdef NGLOG_ENABLE_LOCK_METRICS
+TEST(Logging, DirectSinkWithoutRegisteredSinksDoesNotLockSinkRegistry) {
+  FlagSaver saver;
+  FLAGS_logtostderr = true;
+  internal::ResetLockMetrics();
+
+  TestLogSinkImpl sink;
+  LOG_TO_SINK_BUT_NOT_TO_LOGFILE(&sink, INFO)
+      << "Log without registered sinks.";
+
+  const internal::LockMetrics metrics =
+      internal::GetLockMetrics(internal::LockKind::kSink);
+  EXPECT_EQ(metrics.acquisitions, 0U);
+}
+#endif
 
 // For testing using CHECK*() on anonymous enums.
 enum { CASE_A, CASE_B };

--- a/src/ng-log/logging.h
+++ b/src/ng-log/logging.h
@@ -1331,6 +1331,7 @@ class NGLOG_EXPORT LogMessage {
   // Fully internal SendMethod cases:
   void SendToSinkAndLog();  // Send to sink if provided and dispatch to the logs
   void SendToSink();        // Send to sink if provided, do nothing otherwise.
+  void SendToRegisteredSinks();
 
   // Write to string if provided and dispatch to the logs.
   void WriteToStringAndLog();


### PR DESCRIPTION
Run sink callbacks outside the global logging lock so concurrent messages do not serialize on user code. Avoid the sink registry read lock when no sinks are registered.